### PR TITLE
Fix vertex offsets for lod0

### DIFF
--- a/Files/MdlFile.Write.cs
+++ b/Files/MdlFile.Write.cs
@@ -42,12 +42,12 @@ public partial class MdlFile
         w.Write(totalSize - StackSize - FileHeaderSize);
         w.Write((ushort)VertexDeclarations.Length);
         w.Write((ushort)Materials.Length);
-        w.Write(VertexOffset[0] > 0 ? VertexOffset[0] + totalSize : 0u);
-        w.Write(VertexOffset[1] > 0 ? VertexOffset[1] + totalSize : 0u);
-        w.Write(VertexOffset[2] > 0 ? VertexOffset[2] + totalSize : 0u);
-        w.Write(IndexOffset[0] > 0 ? IndexOffset[0] + totalSize : 0u);
-        w.Write(IndexOffset[1] > 0 ? IndexOffset[1] + totalSize : 0u);
-        w.Write(IndexOffset[2] > 0 ? IndexOffset[2] + totalSize : 0u);
+        w.Write(0 < LodCount ? VertexOffset[0] + totalSize : 0u);
+        w.Write(1 < LodCount ? VertexOffset[1] + totalSize : 0u);
+        w.Write(2 < LodCount ? VertexOffset[2] + totalSize : 0u);
+        w.Write(0 < LodCount ? IndexOffset[0] + totalSize : 0u);
+        w.Write(1 < LodCount ? IndexOffset[1] + totalSize : 0u);
+        w.Write(2 < LodCount ? IndexOffset[2] + totalSize : 0u);
         w.Write(VertexBufferSize[0]);
         w.Write(VertexBufferSize[1]);
         w.Write(VertexBufferSize[2]);

--- a/Files/MdlFile.cs
+++ b/Files/MdlFile.cs
@@ -96,13 +96,10 @@ public partial class MdlFile : IWritable
         IndexOffset      = header.IndexOffset;
 
         var dataOffset = FileHeaderSize + header.RuntimeSize + header.StackSize;
-        for (var i = 0; i < 3; ++i)
+        for (var i = 0; i < LodCount; ++i)
         {
-            if (VertexOffset[i] > 0)
-                VertexOffset[i] -= dataOffset;
-
-            if (IndexOffset[i] > 0)
-                IndexOffset[i] -= dataOffset;
+            VertexOffset[i] -= dataOffset;
+            IndexOffset[i] -= dataOffset;
         }
 
         VertexDeclarations = new MdlStructs.VertexDeclarationStruct[header.VertexDeclarationCount];


### PR DESCRIPTION
oops. i'm an idiot, and all my test data had extraneous padding that meant this never showed up.

lod 0's vertex offset relative to the main binary buffer is typically 0, as the binary buffer is laid out as `[lod0verts, lod0idxs, lod1verts, etc...]`. as such, checking if an (in-memory adjusted) offset is 0 before adding in the meta size during writing means that lod0's vertex offset will never be updated.

this fixes that by using the lod count to decide if adjustments should be made, rather than the value.

---

my local checkout's submodules are in an absolute _state_ right now, so this hasn't been tested against penumbra's `master`, as i can't get it to build at all - it _has_ been tested against an older checkout that still builds. if you can just do a re-save with this on latest as a smoke test that'd ease my concerns a little. changing a material to the same value and saving should do the trick - pre-this-fix, the first lod's model would just disappear or crash, post, it should work fine.