### PR TITLE
GameData updates for mdl-import

### DIFF
--- a/Files/MdlFile.Write.cs
+++ b/Files/MdlFile.Write.cs
@@ -42,12 +42,12 @@ public partial class MdlFile
         w.Write(totalSize - StackSize - FileHeaderSize);
         w.Write((ushort)VertexDeclarations.Length);
         w.Write((ushort)Materials.Length);
-        w.Write(VertexOffset[0] > 0 ? VertexOffset[0] + totalSize : 0u);
-        w.Write(VertexOffset[1] > 0 ? VertexOffset[1] + totalSize : 0u);
-        w.Write(VertexOffset[2] > 0 ? VertexOffset[2] + totalSize : 0u);
-        w.Write(IndexOffset[0] > 0 ? IndexOffset[0] + totalSize : 0u);
-        w.Write(IndexOffset[1] > 0 ? IndexOffset[1] + totalSize : 0u);
-        w.Write(IndexOffset[2] > 0 ? IndexOffset[2] + totalSize : 0u);
+        w.Write(0 < LodCount ? VertexOffset[0] + totalSize : 0u);
+        w.Write(1 < LodCount ? VertexOffset[1] + totalSize : 0u);
+        w.Write(2 < LodCount ? VertexOffset[2] + totalSize : 0u);
+        w.Write(0 < LodCount ? IndexOffset[0] + totalSize : 0u);
+        w.Write(1 < LodCount ? IndexOffset[1] + totalSize : 0u);
+        w.Write(2 < LodCount ? IndexOffset[2] + totalSize : 0u);
         w.Write(VertexBufferSize[0]);
         w.Write(VertexBufferSize[1]);
         w.Write(VertexBufferSize[2]);

--- a/Files/MdlFile.cs
+++ b/Files/MdlFile.cs
@@ -83,6 +83,66 @@ public partial class MdlFile : IWritable
 
     public bool Valid { get; }
 
+    public MdlFile()
+    {
+        Version = 16777221;
+        Radius = 0f;
+        ModelClipOutDistance = 0f;
+        ShadowClipOutDistance = 0f;
+        BgChangeMaterialIndex = 0;
+        BgCrestChangeMaterialIndex = 0;
+        Unknown4 = 0;
+        Unknown5 = 0;
+        Unknown6 = 0;
+        Unknown7 = 0;
+        Unknown8 = 0;
+        Unknown9 = 0;
+
+        VertexOffset = [0, 0, 0];
+        IndexOffset = [0, 0, 0];
+        
+        VertexBufferSize = [0, 0, 0];
+        IndexBufferSize = [0, 0, 0];
+        LodCount = 0;
+        EnableIndexBufferStreaming = false;
+        EnableEdgeGeometry = false;
+
+        // NOTE: The flag type doesn't have a .None entry, so setting to 0 manually.
+        Flags1 = 0;
+        Flags2 = 0;
+
+        var emptyBoundingBox = new MdlStructs.BoundingBoxStruct()
+        {
+            Min = [0f, 0f, 0f, 0f],
+            Max = [0f, 0f, 0f, 0f],
+        };
+        BoundingBoxes = emptyBoundingBox;
+        ModelBoundingBoxes = emptyBoundingBox;
+        WaterBoundingBoxes = emptyBoundingBox;
+        VerticalFogBoundingBoxes = emptyBoundingBox;
+
+        VertexDeclarations = [];
+        ElementIds = [];
+        Meshes = [];
+        BoneTables = [];
+        BoneBoundingBoxes = [];
+        SubMeshes = [];
+        ShapeMeshes = [];
+        ShapeValues = [];
+        TerrainShadowMeshes = [];
+        TerrainShadowSubMeshes = [];
+        Lods = [];
+        ExtraLods = [];
+        SubMeshBoneMap = [];
+
+        Attributes = [];
+        Bones = [];
+        Materials = [];
+        Shapes = [];
+
+        RemainingData = [];
+    }
+
     public MdlFile(byte[] data)
     {
         using var stream = new MemoryStream(data);

--- a/Files/MdlFile.cs
+++ b/Files/MdlFile.cs
@@ -96,13 +96,10 @@ public partial class MdlFile : IWritable
         IndexOffset      = header.IndexOffset;
 
         var dataOffset = FileHeaderSize + header.RuntimeSize + header.StackSize;
-        for (var i = 0; i < 3; ++i)
+        for (var i = 0; i < LodCount; ++i)
         {
-            if (VertexOffset[i] > 0)
-                VertexOffset[i] -= dataOffset;
-
-            if (IndexOffset[i] > 0)
-                IndexOffset[i] -= dataOffset;
+            VertexOffset[i] -= dataOffset;
+            IndexOffset[i] -= dataOffset;
         }
 
         VertexDeclarations = new MdlStructs.VertexDeclarationStruct[header.VertexDeclarationCount];

--- a/Files/MdlFile.cs
+++ b/Files/MdlFile.cs
@@ -173,7 +173,17 @@ public partial class MdlFile : IWritable
         for (var i = 0; i < modelHeader.ElementIdCount; i++)
             ElementIds[i] = MdlStructs.ElementIdStruct.Read(r);
 
-        Lods = r.ReadStructuresAsArray<MdlStructs.LodStruct>(3);
+        Lods = new MdlStructs.LodStruct[3];
+        for (var i = 0; i < 3; i++)
+        {
+            var lod = r.ReadStructure<MdlStructs.LodStruct>();
+            if (i < LodCount)
+            {
+                lod.VertexDataOffset -= dataOffset;
+                lod.IndexDataOffset -= dataOffset;
+            }
+            Lods[i] = lod;
+        }
         ExtraLods = modelHeader.ExtraLodEnabled
             ? r.ReadStructuresAsArray<MdlStructs.ExtraLodStruct>(3)
             : Array.Empty<MdlStructs.ExtraLodStruct>();


### PR DESCRIPTION
Mostly two changes
- extending the buffer offset adjustments to the values in the LoD structs themselves - these mirror the values in the main header, and i assume are the result of the sqpack special cased model handling or something.
- adding a blank constructor for MdlFile
	- is there a better way to do this? it seemed really jank but i'm not the most seasoned c# person by any stretch