### PR TITLE
Use variant id 0 as null case (fixes Penumbra#384)

### DIFF
--- a/Data/GamePaths.cs
+++ b/Data/GamePaths.cs
@@ -349,7 +349,7 @@ public static partial class GamePaths
             public static partial Regex Regex();
 
             public static string FolderPath(GenderRace raceCode, BodySlot slot, PrimaryId slotId, Variant variant)
-                => variant.Id == byte.MaxValue
+                => variant.Id == 0
                     ? FolderPath(raceCode, slot, slotId)
                     : $"chara/human/c{raceCode.ToRaceCode()}/obj/{slot.ToSuffix()}/{slot.ToAbbreviation()}{slotId.Id:D4}/material/v{variant.Id:D4}";
 


### PR DESCRIPTION
this is a massive pr, sorry

as discussed on discord, path parsing is already falling back to 0 as a default when no variant is found, and 0 is completely unused as a variant id across all known game paths per reslog2.

this updates folder path generation to consider variant 0 as a null case.

fixes https://github.com/xivdev/Penumbra/issues/384