### PR TITLE
DT material, stain map and shader stuff

### DIFF
--- a/Files/MaterialStructs/ColorDyeTable.cs
+++ b/Files/MaterialStructs/ColorDyeTable.cs
@@ -1,124 +1,212 @@
+using Penumbra.GameData.Files.Utility;
+
 namespace Penumbra.GameData.Files.MaterialStructs;
 
-// TODO those values are not correct at all, just taken from the old values for now.
-public unsafe struct ColorDyeTable : IEnumerable<ColorDyeTable.Row>
+public sealed class ColorDyeTable : IEnumerable<ColorDyeTable.Row>, IColorDyeTable
 {
     /// <inheritdoc cref="ColorTable.Row"/>
-    public struct Row
+    public struct Row : IEquatable<Row>
     {
         public const int  Size = 4;
         private      uint _data;
 
         public ushort Template
         {
-            get => (ushort)(_data >> 10);
-            set => _data = (_data & 0x03FFu) | ((uint)value << 10);
+            readonly get => (ushort)((_data >> 16) & 0x7FF);
+            set => _data = (_data & ~0x7FF0000u) | ((uint)(value & 0x7FF) << 16);
         }
 
-        public bool Diffuse
+        public byte Channel
         {
-            get => (_data & 0x0001) != 0;
+            readonly get => (byte)((_data >> 27) & 0x3);
+            set => _data = (_data & ~0x18000000u) | ((uint)(value & 0x3) << 27);
+        }
+
+        public bool DiffuseColor
+        {
+            readonly get => (_data & 0x0001) != 0;
             set => _data = value ? _data | 0x0001u : _data & ~0x0001u;
         }
 
-        public bool Specular
+        public bool SpecularColor
         {
-            get => (_data & 0x0002) != 0;
+            readonly get => (_data & 0x0002) != 0;
             set => _data = value ? _data | 0x0002u : _data & ~0x0002u;
         }
 
-        public bool Emissive
+        public bool EmissiveColor
         {
-            get => (_data & 0x0004) != 0;
+            readonly get => (_data & 0x0004) != 0;
             set => _data = value ? _data | 0x0004u : _data & ~0x0004u;
         }
 
-        public bool Gloss
+        public bool Scalar3
         {
-            get => (_data & 0x0008) != 0;
+            readonly get => (_data & 0x0008) != 0;
             set => _data = value ? _data | 0x0008u : _data & ~0x0008u;
         }
 
-        public bool SpecularStrength
+        public bool Metalness
         {
-            get => (_data & 0x0010) != 0;
+            readonly get => (_data & 0x0010) != 0;
             set => _data = value ? _data | 0x0010u : _data & ~0x0010u;
         }
 
-        public bool Unk1
+        public bool Roughness
         {
-            get => (_data & 0x0020) != 0;
+            readonly get => (_data & 0x0020) != 0;
             set => _data = value ? _data | 0x0020u : _data & ~0x0020u;
         }
 
-        public bool Unk2
+        public bool SheenRate
         {
-            get => (_data & 0x0040) != 0;
+            readonly get => (_data & 0x0040) != 0;
             set => _data = value ? _data | 0x0040u : _data & ~0x0040u;
         }
 
-        public bool Unk3
+        public bool SheenTintRate
         {
-            get => (_data & 0x0080) != 0;
+            readonly get => (_data & 0x0080) != 0;
             set => _data = value ? _data | 0x0080u : _data & ~0x0080u;
         }
 
-        public bool Unk4
+        public bool SheenAperture
         {
-            get => (_data & 0x0100) != 0;
+            readonly get => (_data & 0x0100) != 0;
             set => _data = value ? _data | 0x0100u : _data & ~0x0100u;
         }
 
-        public bool Unk5
+        public bool Anisotropy
         {
-            get => (_data & 0x0200) != 0;
+            readonly get => (_data & 0x0200) != 0;
             set => _data = value ? _data | 0x0200u : _data & ~0x0200u;
         }
+
+        public bool SphereMapIndex
+        {
+            readonly get => (_data & 0x0400) != 0;
+            set => _data = value ? _data | 0x0400u : _data & ~0x0400u;
+        }
+
+        public bool SphereMapMask
+        {
+            readonly get => (_data & 0x0800) != 0;
+            set => _data = value ? _data | 0x0800u : _data & ~0x0200u;
+        }
+
+        public Row(in LegacyColorDyeTable.Row oldRow)
+        {
+            Template      = oldRow.Template;
+            DiffuseColor  = oldRow.DiffuseColor;
+            SpecularColor = oldRow.SpecularColor;
+            EmissiveColor = oldRow.EmissiveColor;
+            Scalar3       = oldRow.Shininess;
+            Metalness     = oldRow.SpecularMask;
+        }
+
+        public override readonly bool Equals([NotNullWhen(true)] object? obj)
+            => obj is Row other && Equals(other);
+
+        public readonly bool Equals(Row other)
+            => _data == other._data;
+
+        public override readonly int GetHashCode()
+            => _data.GetHashCode();
+
+        public static bool operator ==(Row row1, Row row2)
+            => row1.Equals(row2);
+
+        public static bool operator !=(Row row1, Row row2)
+            => !row1.Equals(row2);
     }
 
-    public const  int  NumRows = 32;
-    private fixed uint _rowData[NumRows];
+    [InlineArray(NumRows)]
+    private struct Table
+    {
+        [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "InlineArray")]
+        private Row _element0;
+    }
+
+    public const int NumRows = 32;
+    public const int Size    = NumRows * Row.Size;
+
+    int IColorDyeTable.RowSize => Row.Size;
+    int IColorDyeTable.Height  => NumRows;
+    int IColorDyeTable.Size    => Size;
+
+    private Table _rowData;
 
     public ref Row this[int i]
-    {
-        get
-        {
-            fixed (uint* ptr = _rowData)
-            {
-                return ref ((Row*)ptr)[i];
-            }
-        }
-    }
+        => ref _rowData[i];
 
     public IEnumerator<Row> GetEnumerator()
     {
         for (var i = 0; i < NumRows; ++i)
-            yield return this[i];
+            yield return _rowData[i];
     }
 
     IEnumerator IEnumerable.GetEnumerator()
         => GetEnumerator();
 
-    public ReadOnlySpan<byte> AsBytes()
+    public Span<byte> AsBytes()
+        => MemoryMarshal.AsBytes(_rowData[..]);
+
+    public Span<byte> RowAsBytes(int i)
+        => MemoryMarshal.AsBytes(new Span<Row>(ref _rowData[i]));
+
+    public bool SetDefault()
     {
-        fixed (uint* ptr = _rowData)
-        {
-            return new ReadOnlySpan<byte>(ptr, NumRows * sizeof(ushort));
-        }
+        var ret = false;
+        for (var i = 0; i < NumRows; ++i)
+            ret |= SetDefaultRow(i);
+
+        return ret;
     }
 
-    internal ColorDyeTable(in LegacyColorDyeTable oldTable)
+    public bool SetDefaultRow(int i)
     {
-        for (var i = 0; i < LegacyColorDyeTable.NumRows; ++i)
-        {
-            var     oldRow = oldTable[i];
-            ref var row    = ref this[i];
-            row.Template         = oldRow.Template;
-            row.Diffuse          = oldRow.Diffuse;
-            row.Specular         = oldRow.Specular;
-            row.Emissive         = oldRow.Emissive;
-            row.Gloss            = oldRow.Gloss;
-            row.SpecularStrength = oldRow.SpecularStrength;
-        }
+        if (_rowData[i] == default)
+            return false;
+
+        _rowData[i] = default;
+        return true;
     }
+
+    public ColorDyeTable()
+    {
+        SetDefault();
+    }
+
+    private ColorDyeTable(ref SpanBinaryReader reader)
+    {
+        reader.Read<Row>(NumRows).CopyTo(_rowData);
+    }
+
+    public ColorDyeTable(IColorDyeTable other)
+    {
+        if (other is LegacyColorDyeTable oldTable)
+        {
+            for (var i = 0; i < LegacyColorDyeTable.NumRows; ++i)
+                _rowData[i] = new Row(oldTable[i]);
+            for (var i = LegacyColorDyeTable.NumRows; i < NumRows; ++i)
+                SetDefaultRow(i);
+        }
+        else if (other is ColorDyeTable table)
+        {
+            for (var i = 0; i < NumRows; ++i)
+                _rowData[i] = table[i];
+        }
+        else
+            SetDefault();
+    }
+
+    public static ColorDyeTable CastOrConvert(IColorDyeTable other)
+        => other is ColorDyeTable table ? table : new(other);
+
+    /// <summary>
+    /// Attempts to read a color dye table from the given reader.
+    /// If the reader doesn't hold enough data, nothing will be read, and this will return a default table.
+    /// </summary>
+    public static ColorDyeTable TryReadFrom(ref SpanBinaryReader reader)
+        => reader.Remaining >= Size ? new(ref reader) : new();
 }

--- a/Files/MaterialStructs/ColorTable.cs
+++ b/Files/MaterialStructs/ColorTable.cs
@@ -1,153 +1,336 @@
+using Penumbra.GameData.Files.StainMapStructs;
+using Penumbra.GameData.Files.Utility;
+using Penumbra.GameData.Structs;
+
 namespace Penumbra.GameData.Files.MaterialStructs;
 
 // TODO: those values are not correct at all, just taken from legacy for now.
-public unsafe struct ColorTable : IEnumerable<ColorTable.Row>
+public sealed class ColorTable : IEnumerable<ColorTable.Row>, IColorTable
 {
     /// <summary>
     /// The number after the parameter is the bit in the dye flags.
     /// <code>
     /// #       |    X (+0)    |    |    Y (+1)    |    |    Z (+2)   |    |   W (+3)    |
     /// --------------------------------------------------------------------------------------
-    /// 0 (+ 0) |    Diffuse.R |  0 |    Diffuse.G |  0 |   Diffuse.B |  0 |             |  
+    /// 0 (+ 0) |    Diffuse.R |  0 |    Diffuse.G |  0 |   Diffuse.B |  0 |         Unk |  
     /// 1 (+ 4) |   Specular.R |  1 |   Specular.G |  1 |  Specular.B |  1 |         Unk |
     /// 2 (+ 8) |   Emissive.R |  2 |   Emissive.G |  2 |  Emissive.B |  2 |         Unk |  3
-    /// 3 (+12) |          Unk |  6 |          Unk |  7 |         Unk |  8 |             |
-    /// 4 (+16) |          Unk |  5 |              |    |         Unk |  4 |         Unk |  9
-    /// 5 (+20) |              |    |          Unk | 11 |             |    |             |   
-    /// 6 (+24) |   Shader Idx |    |   Tile Index |    |         Unk |    |         Unk | 10
-    /// 7 (+28) | Tile Count.X |    | Tile Count.Y |    | Tile Skew.X |    | Tile Skew.Y |
+    /// 3 (+12) |   Sheen Rate |  6 |   Sheen Tint |  7 |  Sheen Apt. |  8 |         Unk |
+    /// 4 (+16) |   Rougnhess? |  5 |              |    |  Metalness? |  4 |  Anisotropy |  9
+    /// 5 (+20) |          Unk |    |  Sphere Mask | 11 |         Unk |    |         Unk |   
+    /// 6 (+24) |   Shader Idx |    |   Tile Index |    |  Tile Alpha |    |  Sphere Idx | 10
+    /// 7 (+28) |   Tile XF UU |    |   Tile XF UV |    |  Tile XF VU |    |  Tile XF VV |
     /// </code>
     /// </summary>
-    public struct Row
+    [InlineArray(NumVec4 * Halves)]
+    public struct Row : IEquatable<Row>
     {
         public const int NumVec4 = 8;
         public const int Halves  = 4;
         public const int Size    = NumVec4 * Halves * 2;
 
-        private fixed ushort _data[NumVec4 * Halves];
+        [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "InlineArray")]
+        private Half _element0;
 
-        public static readonly Row Default = new();
-
-        public Vector3 Diffuse
+        public static readonly Row LegacyDefault = new(LegacyColorTable.Row.Default);
+        public static readonly Row Default       = new()
         {
-            readonly get => new(ToFloat(0), ToFloat(1), ToFloat(2));
+            DiffuseColor   = HalfColor.White,
+            Scalar3        = Half.One,
+            SpecularColor  = HalfColor.White,
+            Scalar7        = Half.Zero,
+            EmissiveColor  = HalfColor.Black,
+            Scalar11       = Half.One,
+            SheenRate      = (Half)0.1f,
+            SheenTintRate  = (Half)0.2f,
+            SheenAperture  = (Half)5.0f,
+            Scalar15       = Half.Zero,
+            Roughness      = (Half)0.5f,
+            Scalar17       = Half.Zero,
+            Metalness      = Half.Zero,
+            Anisotropy     = Half.Zero,
+            Scalar20       = Half.Zero,
+            SphereMapMask  = Half.Zero,
+            Scalar22       = Half.Zero,
+            Scalar23       = Half.Zero,
+            ShaderId       = 0,
+            TileIndex      = 0,
+            TileAlpha      = Half.One,
+            SphereMapIndex = 0,
+            TileTransform  = HalfMatrix2x2.ScaledIdentity((Half)16.0f),
+        };
+
+        public HalfColor DiffuseColor
+        {
+            readonly get => new(this[0], this[1], this[2]);
             set
             {
-                _data[0] = FromFloat(value.X);
-                _data[1] = FromFloat(value.Y);
-                _data[2] = FromFloat(value.Z);
+                this[0] = value.Red;
+                this[1] = value.Green;
+                this[2] = value.Blue;
             }
         }
 
-        public Vector3 Specular
+        public Half Scalar3
         {
-            readonly get => new(ToFloat(4), ToFloat(5), ToFloat(6));
+            readonly get => this[3];
+            set => this[3] = value;
+        }
+
+        public HalfColor SpecularColor
+        {
+            readonly get => new(this[4], this[5], this[6]);
             set
             {
-                _data[4] = FromFloat(value.X);
-                _data[5] = FromFloat(value.Y);
-                _data[6] = FromFloat(value.Z);
+                this[4] = value.Red;
+                this[5] = value.Green;
+                this[6] = value.Blue;
             }
         }
 
-        public Vector3 Emissive
+        public Half Scalar7
         {
-            readonly get => new(ToFloat(8), ToFloat(9), ToFloat(10));
+            readonly get => this[7];
+            set => this[7] = value;
+        }
+
+        public HalfColor EmissiveColor
+        {
+            readonly get => new(this[8], this[9], this[10]);
             set
             {
-                _data[8]  = FromFloat(value.X);
-                _data[9]  = FromFloat(value.Y);
-                _data[10] = FromFloat(value.Z);
+                this[8]  = value.Red;
+                this[9]  = value.Green;
+                this[10] = value.Blue;
             }
         }
 
-        public Vector2 MaterialRepeat
+        public Half Scalar11
         {
-            readonly get => new(ToFloat(28), ToFloat(29));
+            readonly get => this[11];
+            set => this[11] = value;
+        }
+
+        public Half SheenRate
+        {
+            readonly get => this[12];
+            set => this[12] = value;
+        }
+
+        public Half SheenTintRate
+        {
+            readonly get => this[13];
+            set => this[13] = value;
+        }
+
+        public Half SheenAperture
+        {
+            readonly get => this[14];
+            set => this[14] = value;
+        }
+
+        public Half Scalar15
+        {
+            readonly get => this[15];
+            set => this[15] = value;
+        }
+
+        public Half Roughness
+        {
+            readonly get => this[16];
+            set => this[16] = value;
+        }
+
+        public Half Scalar17
+        {
+            readonly get => this[17];
+            set => this[17] = value;
+        }
+
+        public Half Metalness
+        {
+            readonly get => this[18];
+            set => this[18] = value;
+        }
+
+        public Half Anisotropy
+        {
+            readonly get => this[19];
+            set => this[19] = value;
+        }
+
+        public Half Scalar20
+        {
+            readonly get => this[20];
+            set => this[20] = value;
+        }
+
+        public Half SphereMapMask
+        {
+            readonly get => this[21];
+            set => this[21] = value;
+        }
+
+        public Half Scalar22
+        {
+            readonly get => this[22];
+            set => this[22] = value;
+        }
+
+        public Half Scalar23
+        {
+            readonly get => this[23];
+            set => this[23] = value;
+        }
+
+        public ushort ShaderId
+        {
+            readonly get => (ushort)this[24];
+            set => this[24] = (Half)value;
+        }
+
+        public ushort TileIndex
+        {
+            readonly get => (ushort)((float)this[25] * 64f);
+            set => this[25] = (Half)((value + 0.5f) / 64f);
+        }
+
+        public Half TileAlpha
+        {
+            readonly get => this[26];
+            set => this[26] = value;
+        }
+
+        public ushort SphereMapIndex
+        {
+            readonly get => (ushort)this[27];
+            set => this[27] = (Half)value;
+        }
+
+        public HalfMatrix2x2 TileTransform
+        {
+            readonly get => new(this[28], this[29], this[30], this[31]);
             set
             {
-                _data[28] = FromFloat(value.X);
-                _data[29] = FromFloat(value.Y);
+                this[28] = value.UU;
+                this[29] = value.UV;
+                this[30] = value.VU;
+                this[31] = value.VV;
             }
         }
 
-        public Vector2 MaterialSkew
+        public bool ApplyDye(ColorDyeTable.Row dyeRow, LegacyDyePack dyes)
         {
-            readonly get => new(ToFloat(30), ToFloat(31));
-            set
-            {
-                _data[30] = FromFloat(value.X);
-                _data[31] = FromFloat(value.Y);
-            }
-        }
+            // This does a legacy interpretation of the new structures.
 
-        public float SpecularStrength
-        {
-            readonly get => ToFloat(3);
-            set => _data[3] = FromFloat(value);
-        }
-
-        public float GlossStrength
-        {
-            readonly get => ToFloat(11);
-            set => _data[11] = FromFloat(value);
-        }
-
-        public ushort TileSet
-        {
-            readonly get => (ushort)(ToFloat(25) * 64f);
-            set => _data[25] = FromFloat((value + 0.5f) / 64f);
-        }
-
-        public readonly Span<Half> AsHalves()
-        {
-            fixed (ushort* ptr = _data)
-            {
-                return new Span<Half>(ptr, NumVec4 * Halves);
-            }
-        }
-
-        private readonly float ToFloat(int idx)
-            => (float)BitConverter.UInt16BitsToHalf(_data[idx]);
-
-        private static ushort FromFloat(float x)
-            => BitConverter.HalfToUInt16Bits((Half)x);
-
-        public bool ApplyDyeTemplate2(ColorDyeTable.Row dyeRow, StmFile.DyePack dye)
-            // TODO
-            => false;
-
-        public bool ApplyDyeTemplate1(ColorDyeTable.Row dyeRow, StmFile.DyePack dye)
-        {
             var ret = false;
 
-            if (dyeRow.Diffuse && Diffuse != dye.Diffuse)
+            if (dyeRow.DiffuseColor && DiffuseColor != dyes.DiffuseColor)
             {
-                Diffuse = dye.Diffuse;
+                DiffuseColor = dyes.DiffuseColor;
+                ret          = true;
+            }
+
+            if (dyeRow.SpecularColor && SpecularColor != dyes.SpecularColor && dyes.SpecularColor != HalfColor.Black)
+            {
+                SpecularColor = dyes.SpecularColor;
+                ret           = true;
+            }
+
+            if (dyeRow.EmissiveColor && EmissiveColor != dyes.EmissiveColor)
+            {
+                EmissiveColor = dyes.EmissiveColor;
+                ret           = true;
+            }
+
+            if (dyeRow.Scalar3 && Scalar3 != dyes.Shininess)
+            {
+                Scalar3 = dyes.Shininess;
                 ret     = true;
             }
 
-            if (dyeRow.Specular && Specular != dye.Specular)
+            if (dyeRow.Metalness && Scalar7 != dyes.SpecularMask)
             {
-                Specular = dye.Specular;
+                Scalar7 = dyes.SpecularMask;
+                ret     = true;
+            }
+
+            return ret;
+        }
+
+        public bool ApplyDye(ColorDyeTable.Row dyeRow, DyePack dye)
+        {
+            var ret = false;
+
+            if (dyeRow.DiffuseColor && DiffuseColor != dye.DiffuseColor)
+            {
+                DiffuseColor = dye.DiffuseColor;
+                ret          = true;
+            }
+
+            if (dyeRow.SpecularColor && SpecularColor != dye.SpecularColor && dye.SpecularColor != HalfColor.Black)
+            {
+                SpecularColor = dye.SpecularColor;
+                ret           = true;
+            }
+
+            if (dyeRow.EmissiveColor && EmissiveColor != dye.EmissiveColor)
+            {
+                EmissiveColor = dye.EmissiveColor;
+                ret           = true;
+            }
+
+            if (dyeRow.Scalar3 && Scalar11 != dye.Scalar3)
+            {
+                Scalar11 = dye.Scalar3;
                 ret      = true;
             }
 
-            if (dyeRow.SpecularStrength && SpecularStrength != dye.SpecularPower)
+            if (dyeRow.Metalness && Metalness != dye.Metalness)
             {
-                SpecularStrength = dye.SpecularPower;
-                ret              = true;
+                Metalness = dye.Metalness;
+                ret       = true;
             }
 
-            if (dyeRow.Emissive && Emissive != dye.Emissive)
+            if (dyeRow.Roughness && Roughness != dye.Roughness)
             {
-                Emissive = dye.Emissive;
+                Roughness = dye.Roughness;
+                ret       = true;
+            }
+
+            if (dyeRow.SheenRate && SheenRate != dye.SheenRate)
+            {
+                SheenRate = dye.SheenRate;
+                ret       = true;
+            }
+
+            if (dyeRow.SheenTintRate && SheenTintRate != dye.SheenTintRate)
+            {
+                SheenTintRate = dye.SheenTintRate;
+                ret           = true;
+            }
+
+            if (dyeRow.SheenAperture && SheenAperture != dye.SheenAperture)
+            {
+                SheenAperture = dye.SheenAperture;
+                ret           = true;
+            }
+
+            if (dyeRow.Anisotropy && Anisotropy != dye.Anisotropy)
+            {
+                Anisotropy = dye.Anisotropy;
+                ret        = true;
+            }
+
+            if (dyeRow.SphereMapIndex && this[27] != dye.RawSphereMapIndex)
+            {
+                this[27] = dye.RawSphereMapIndex;
                 ret      = true;
             }
 
-            if (dyeRow.Gloss && GlossStrength != dye.Gloss)
+            if (dyeRow.SphereMapMask && SphereMapMask != dye.SphereMapMask)
             {
-                GlossStrength = dye.Gloss;
+                SphereMapMask = dye.SphereMapMask;
                 ret           = true;
             }
 
@@ -156,67 +339,191 @@ public unsafe struct ColorTable : IEnumerable<ColorTable.Row>
 
         public Row(in LegacyColorTable.Row oldRow)
         {
-            Diffuse          = oldRow.Diffuse;
-            Specular         = oldRow.Specular;
-            Emissive         = oldRow.Emissive;
-            MaterialRepeat   = oldRow.MaterialRepeat;
-            MaterialSkew     = oldRow.MaterialSkew;
-            SpecularStrength = oldRow.SpecularStrength;
-            GlossStrength    = oldRow.GlossStrength;
-            TileSet          = oldRow.TileSet;
+            DiffuseColor     = oldRow.DiffuseColor;
+            Scalar3          = oldRow.Shininess;
+            SpecularColor    = oldRow.SpecularColor;
+            Scalar7          = oldRow.SpecularMask;
+            EmissiveColor    = oldRow.EmissiveColor;
+            TileIndex        = oldRow.TileIndex;
+            TileAlpha        = Half.One;
+            TileTransform    = oldRow.TileTransform;
         }
+
+        public override readonly bool Equals([NotNullWhen(true)] object? obj)
+            => obj is Row other && Equals(other);
+
+        public readonly bool Equals(Row other)
+            => this[..].SequenceEqual(other[..]);
+
+        public override readonly int GetHashCode()
+        {
+            var hc = new HashCode();
+            hc.AddBytes(MemoryMarshal.AsBytes(new ReadOnlySpan<Row>(in this)));
+            return hc.ToHashCode();
+        }
+
+        public static bool operator ==(Row row1, Row row2)
+            => row1.Equals(row2);
+
+        public static bool operator !=(Row row1, Row row2)
+            => !row1.Equals(row2);
     }
 
-    public const  int  NumRows = 32;
-    private fixed byte _rowData[NumRows * Row.Size];
+    [InlineArray(NumRows)]
+    private struct Table
+    {
+        [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "InlineArray")]
+        private Row _element0;
+    }
+
+    public const int NumRows = 32;
+    public const int Size    = NumRows * Row.Size;
+
+    public const byte DimensionLogs = 0x53;
+
+    int IColorTable.Width   => Row.NumVec4;
+    int IColorTable.RowSize => Row.Size;
+    int IColorTable.Height  => NumRows;
+    int IColorTable.Size    => Size;
+    byte IColorTable.DimensionLogs => DimensionLogs;
+
+    private Table _rowData;
 
     public ref Row this[int i]
-    {
-        get
-        {
-            fixed (byte* ptr = _rowData)
-            {
-                return ref ((Row*)ptr)[i];
-            }
-        }
-    }
+        => ref _rowData[i];
 
     public IEnumerator<Row> GetEnumerator()
     {
         for (var i = 0; i < NumRows; ++i)
-            yield return this[i];
+            yield return _rowData[i];
     }
 
     IEnumerator IEnumerable.GetEnumerator()
         => GetEnumerator();
 
-    public readonly ReadOnlySpan<byte> AsBytes()
-    {
-        fixed (byte* ptr = _rowData)
-        {
-            return new ReadOnlySpan<byte>(ptr, NumRows * Row.Size);
-        }
-    }
+    public Span<byte> AsBytes()
+        => MemoryMarshal.AsBytes(_rowData[..]);
 
-    public readonly Span<Half> AsHalves()
-    {
-        fixed (byte* ptr = _rowData)
-        {
-            return new Span<Half>((Half*)ptr, NumRows * 16);
-        }
-    }
+    public Span<Half> AsHalves()
+        => MemoryMarshal.Cast<Row, Half>(_rowData);
 
-    public void SetDefault()
+    public Span<byte> RowAsBytes(int i)
+        => MemoryMarshal.AsBytes(_rowData[i][..]);
+
+    public Span<Half> RowAsHalves(int i)
+        => _rowData[i];
+
+    public Span<Row> AsRows()
+        => _rowData;
+
+    public bool SetDefault()
     {
+        var ret = false;
         for (var i = 0; i < NumRows; ++i)
-            this[i] = Row.Default;
+            ret |= SetDefaultRow(i);
+
+        return ret;
     }
 
-    public ColorTable(in LegacyColorTable oldTable)
+    public bool SetDefaultRow(int i)
     {
-        for (var i = 0; i < LegacyColorTable.NumRows; ++i)
-            this[i] = new Row(oldTable[i]);
+        if (_rowData[i] == Row.Default)
+            return false;
+
+        _rowData[i] = Row.Default;
+        return true;
     }
+
+    public bool ApplyDye(StmFile<DyePack> stm, ReadOnlySpan<StainId> stainIds, ColorDyeTable dyeTable)
+    {
+        if (stainIds.Length == 0)
+            return false;
+
+        var ret = false;
+        for (var rowIdx = 0; rowIdx < ColorDyeTable.NumRows; ++rowIdx)
+        {
+            var dyeRow  = dyeTable[rowIdx];
+            var stainId = dyeRow.Channel < stainIds.Length ? stainIds[dyeRow.Channel] : 0;
+            if (stainId != 0 && stm.TryGetValue(dyeRow.Template, stainId, out var dyes))
+                ret |= _rowData[rowIdx].ApplyDye(dyeRow, dyes);
+        }
+
+        return ret;
+    }
+
+    public bool ApplyDye(StmFile<LegacyDyePack> stm, ReadOnlySpan<StainId> stainIds, ColorDyeTable dyeTable)
+    {
+        if (stainIds.Length == 0)
+            return false;
+
+        var ret = false;
+        for (var rowIdx = 0; rowIdx < ColorDyeTable.NumRows; ++rowIdx)
+        {
+            var dyeRow  = dyeTable[rowIdx];
+            var stainId = dyeRow.Channel < stainIds.Length ? stainIds[dyeRow.Channel] : 0;
+            if (stainId != 0 && stm.TryGetValue(dyeRow.Template, stainId, out var dyes))
+                ret |= _rowData[rowIdx].ApplyDye(dyeRow, dyes);
+        }
+
+        return ret;
+    }
+
+    public bool ApplyDyeToRow(StmFile<DyePack> stm, ReadOnlySpan<StainId> stainIds, int rowIdx, ColorDyeTable.Row dyeRow)
+    {
+        if (rowIdx < 0 || rowIdx >= NumRows || stainIds.Length == 0)
+            return false;
+
+        var ret     = false;
+        var stainId = dyeRow.Channel < stainIds.Length ? stainIds[dyeRow.Channel] : 0;
+        if (stainId != 0 && stm.TryGetValue(dyeRow.Template, stainId, out var dyes))
+            ret |= _rowData[rowIdx].ApplyDye(dyeRow, dyes);
+
+        return ret;
+    }
+
+    public bool ApplyDyeToRow(StmFile<LegacyDyePack> stm, ReadOnlySpan<StainId> stainIds, int rowIdx, ColorDyeTable.Row dyeRow)
+    {
+        if (rowIdx < 0 || rowIdx >= NumRows || stainIds.Length == 0)
+            return false;
+
+        var ret     = false;
+        var stainId = dyeRow.Channel < stainIds.Length ? stainIds[dyeRow.Channel] : 0;
+        if (stainId != 0 && stm.TryGetValue(dyeRow.Template, stainId, out var dyes))
+            ret |= _rowData[rowIdx].ApplyDye(dyeRow, dyes);
+
+        return ret;
+    }
+
+    public ColorTable()
+    {
+        SetDefault();
+    }
+
+    private ColorTable(ref SpanBinaryReader reader)
+    {
+        _rowData = reader.Read<Table>();
+    }
+
+    public ColorTable(IColorTable other)
+    {
+        if (other is LegacyColorTable oldTable)
+        {
+            for (var i = 0; i < LegacyColorTable.NumRows; ++i)
+                _rowData[i] = new Row(oldTable[i]);
+            for (var i = LegacyColorTable.NumRows; i < NumRows; ++i)
+                _rowData[i] = Row.LegacyDefault;
+        }
+        else if (other is ColorTable table)
+        {
+            for (var i = 0; i < NumRows; ++i)
+                _rowData[i] = table[i];
+        }
+        else
+            SetDefault();
+    }
+
+    public static ColorTable CastOrConvert(IColorTable other)
+        => other is ColorTable table ? table : new(other);
 
     public override string ToString()
     {
@@ -225,10 +532,17 @@ public unsafe struct ColorTable : IEnumerable<ColorTable.Row>
         {
             var row = this[i];
             for (var j = 0; j < Row.NumVec4 * Row.Halves; ++j)
-                sb.Append($"{((Half*)(&row))[j]:F1} ");
+                sb.Append($"{row[j]:F1} ");
             sb[^1] = '\n';
         }
 
         return sb.ToString();
     }
+
+    /// <summary>
+    /// Attempts to read a legacy color table from the given reader.
+    /// If the reader doesn't hold enough data, nothing will be read, and this will return a default table.
+    /// </summary>
+    public static ColorTable TryReadFrom(ref SpanBinaryReader reader)
+        => reader.Remaining >= Size ? new(ref reader) : new();
 }

--- a/Files/MaterialStructs/IColorDyeTable.cs
+++ b/Files/MaterialStructs/IColorDyeTable.cs
@@ -1,0 +1,41 @@
+namespace Penumbra.GameData.Files.MaterialStructs;
+
+public interface IColorDyeTable
+{
+    /// <summary>
+    /// The size of one row of this table, in bytes.
+    /// </summary>
+    int RowSize { get; }
+
+    /// <summary>
+    /// The height of this table, in rows.
+    /// </summary>
+    int Height { get; }
+
+    /// <summary>
+    /// The size of this table, in bytes.
+    /// </summary>
+    int Size { get; }
+
+    /// <summary>
+    /// Gets the contents of this table, as bytes.
+    /// </summary>
+    Span<byte> AsBytes();
+
+    /// <summary>
+    /// Gets the contents of a row, as <see cref="Half"/>.
+    /// </summary>
+    Span<byte> RowAsBytes(int i);
+
+    /// <summary>
+    /// Resets this table to default values.
+    /// </summary>
+    /// <returns> Whether something actually changed. </returns>
+    bool SetDefault();
+
+    /// <summary>
+    /// Resets a row to default values.
+    /// </summary>
+    /// <returns> Whether something actually changed. </returns>
+    bool SetDefaultRow(int i);
+}

--- a/Files/MaterialStructs/IColorTable.cs
+++ b/Files/MaterialStructs/IColorTable.cs
@@ -1,0 +1,63 @@
+namespace Penumbra.GameData.Files.MaterialStructs;
+
+public interface IColorTable
+{
+    /// <summary>
+    /// The width of this table, in vectors of 4 <see cref="Half"/> per row.
+    /// </summary>
+    int Width { get; }
+
+    /// <summary>
+    /// The size of one row of this table, in bytes.
+    /// </summary>
+    int RowSize { get; }
+
+    /// <summary>
+    /// The height of this table, in rows.
+    /// </summary>
+    int Height { get; }
+
+    /// <summary>
+    /// The size of this table, in bytes.
+    /// </summary>
+    int Size { get; }
+
+    /// <summary>
+    /// Binary logarithms of the dimensions of this table, for <see cref="TableFlags.TableDimensionLogs"/>.
+    /// Low nibble is the log of <see cref="Width"/>, high nibble is the log of <see cref="Height"/>.
+    /// Must be zero (instead of 0x42) for legacy tables.
+    /// </summary>
+    byte DimensionLogs { get; }
+
+    /// <summary>
+    /// Gets the contents of this table, as bytes.
+    /// </summary>
+    Span<byte> AsBytes();
+
+    /// <summary>
+    /// Gets the contents of this table, as <see cref="Half"/>.
+    /// </summary>
+    Span<Half> AsHalves();
+
+    /// <summary>
+    /// Gets the contents of a row, as bytes.
+    /// </summary>
+    Span<byte> RowAsBytes(int i);
+
+    /// <summary>
+    /// Gets the contents of a row, as <see cref="Half"/>.
+    /// </summary>
+    Span<Half> RowAsHalves(int i);
+
+    /// <summary>
+    /// Resets this table to default values.
+    /// </summary>
+    /// <returns> Whether something actually changed. </returns>
+    bool SetDefault();
+
+    /// <summary>
+    /// Resets a row to default values.
+    /// </summary>
+    /// <returns> Whether something actually changed. </returns>
+    bool SetDefaultRow(int i);
+}

--- a/Files/MaterialStructs/LegacyColorDyeTable.cs
+++ b/Files/MaterialStructs/LegacyColorDyeTable.cs
@@ -1,8 +1,10 @@
+using Penumbra.GameData.Files.Utility;
+
 namespace Penumbra.GameData.Files.MaterialStructs;
 
-public unsafe struct LegacyColorDyeTable : IEnumerable<LegacyColorDyeTable.Row>
+public unsafe sealed class LegacyColorDyeTable : IEnumerable<LegacyColorDyeTable.Row>, IColorDyeTable
 {
-    public struct Row
+    public struct Row : IEquatable<Row>
     {
         public const int Size = 2;
 
@@ -10,86 +12,148 @@ public unsafe struct LegacyColorDyeTable : IEnumerable<LegacyColorDyeTable.Row>
 
         public ushort Template
         {
-            get => (ushort)(_data >> 5);
+            readonly get => (ushort)(_data >> 5);
             set => _data = (ushort)((_data & 0x1F) | (value << 5));
         }
 
-        public bool Diffuse
+        public bool DiffuseColor
         {
-            get => (_data & 0x01) != 0;
+            readonly get => (_data & 0x01) != 0;
             set => _data = (ushort)(value ? _data | 0x01 : _data & 0xFFFE);
         }
 
-        public bool Specular
+        public bool SpecularColor
         {
-            get => (_data & 0x02) != 0;
+            readonly get => (_data & 0x02) != 0;
             set => _data = (ushort)(value ? _data | 0x02 : _data & 0xFFFD);
         }
 
-        public bool Emissive
+        public bool EmissiveColor
         {
-            get => (_data & 0x04) != 0;
+            readonly get => (_data & 0x04) != 0;
             set => _data = (ushort)(value ? _data | 0x04 : _data & 0xFFFB);
         }
 
-        public bool Gloss
+        public bool Shininess
         {
-            get => (_data & 0x08) != 0;
+            readonly get => (_data & 0x08) != 0;
             set => _data = (ushort)(value ? _data | 0x08 : _data & 0xFFF7);
         }
 
-        public bool SpecularStrength
+        public bool SpecularMask
         {
-            get => (_data & 0x10) != 0;
+            readonly get => (_data & 0x10) != 0;
             set => _data = (ushort)(value ? _data | 0x10 : _data & 0xFFEF);
         }
 
         public Row(in ColorDyeTable.Row row)
         {
-            Template         = row.Template;
-            Diffuse          = row.Diffuse;
-            Specular         = row.Specular;
-            Emissive         = row.Emissive;
-            Gloss            = row.Gloss;
-            SpecularStrength = row.SpecularStrength;
+            Template      = row.Template;
+            DiffuseColor  = row.DiffuseColor;
+            SpecularColor = row.SpecularColor;
+            EmissiveColor = row.EmissiveColor;
+            Shininess     = row.Scalar3;
+            SpecularMask  = row.Metalness;
         }
+
+        public override readonly bool Equals([NotNullWhen(true)] object? obj)
+            => obj is Row other && Equals(other);
+
+        public readonly bool Equals(Row other)
+            => _data == other._data;
+
+        public override readonly int GetHashCode()
+            => _data.GetHashCode();
+
+        public static bool operator ==(Row row1, Row row2)
+            => row1.Equals(row2);
+
+        public static bool operator !=(Row row1, Row row2)
+            => !row1.Equals(row2);
     }
 
-    public const  int    NumRows     = 16;
-    public const  int    NumUsedRows = 16;
-    private fixed ushort _rowData[NumRows];
+    [InlineArray(NumRows)]
+    private struct Table
+    {
+        [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "InlineArray")]
+        private Row _element0;
+    }
+
+    public const int NumRows = 16;
+    public const int Size    = NumRows * Row.Size;
+
+    int IColorDyeTable.RowSize => Row.Size;
+    int IColorDyeTable.Height  => NumRows;
+    int IColorDyeTable.Size    => Size;
+
+    private Table _rowData;
 
     public ref Row this[int i]
-    {
-        get
-        {
-            fixed (ushort* ptr = _rowData)
-            {
-                return ref ((Row*)ptr)[i];
-            }
-        }
-    }
+        => ref _rowData[i];
 
     public IEnumerator<Row> GetEnumerator()
     {
         for (var i = 0; i < NumRows; ++i)
-            yield return this[i];
+            yield return _rowData[i];
     }
 
     IEnumerator IEnumerable.GetEnumerator()
         => GetEnumerator();
 
-    public ReadOnlySpan<byte> AsBytes()
+    public Span<byte> AsBytes()
+        => MemoryMarshal.AsBytes(_rowData[..]);
+
+    public Span<byte> RowAsBytes(int i)
+        => MemoryMarshal.AsBytes(new Span<Row>(ref _rowData[i]));
+
+    public bool SetDefault()
     {
-        fixed (ushort* ptr = _rowData)
-        {
-            return new ReadOnlySpan<byte>(ptr, NumRows * sizeof(ushort));
-        }
+        var ret = false;
+        for (var i = 0; i < NumRows; ++i)
+            ret |= SetDefaultRow(i);
+
+        return ret;
     }
 
-    public LegacyColorDyeTable(in ColorDyeTable newTable)
+    public bool SetDefaultRow(int i)
     {
-        for (var i = 0; i < NumRows; ++i)
-            this[i] = new Row(newTable[i]);
+        if (_rowData[i] == default)
+            return false;
+
+        _rowData[i] = default;
+        return true;
     }
+
+    public LegacyColorDyeTable()
+    {
+        SetDefault();
+    }
+
+    private LegacyColorDyeTable(ref SpanBinaryReader reader)
+    {
+        reader.Read<Row>(NumRows).CopyTo(_rowData);
+    }
+
+    public LegacyColorDyeTable(IColorDyeTable other)
+    {
+        if (other is ColorDyeTable newTable)
+        {
+            for (var i = 0; i < NumRows; ++i)
+                _rowData[i] = new Row(newTable[i]);
+        }
+        else if (other is LegacyColorDyeTable table)
+        {
+            for (var i = 0; i < NumRows; ++i)
+                _rowData[i] = table[i];
+        }
+        else
+            SetDefault();
+    }
+
+    /// <summary>
+    /// Attempts to read a legacy color dye table from the given reader.
+    /// If the reader doesn't hold enough data, nothing will be read, and this will return a default table.
+    /// </summary>
+    public static LegacyColorDyeTable TryReadFrom(ref SpanBinaryReader reader)
+        => reader.Remaining >= Size ? new(ref reader) : new();
 }

--- a/Files/MaterialStructs/LegacyColorTable.cs
+++ b/Files/MaterialStructs/LegacyColorTable.cs
@@ -1,211 +1,315 @@
+using Penumbra.GameData.Files.StainMapStructs;
+using Penumbra.GameData.Files.Utility;
+using Penumbra.GameData.Structs;
+
 namespace Penumbra.GameData.Files.MaterialStructs;
 
-public unsafe struct LegacyColorTable : IEnumerable<LegacyColorTable.Row>
+public sealed class LegacyColorTable : IEnumerable<LegacyColorTable.Row>, IColorTable
 {
-    public struct Row
+    /// <summary>
+    /// The number after the parameter is the bit in the dye flags.
+    /// <code>
+    /// #       |    X (+0)    |    |    Y (+1)    |    |    Z (+2)   |    |   W (+3)    |
+    /// --------------------------------------------------------------------------------------
+    /// 0 (+ 0) |    Diffuse.R |  0 |    Diffuse.G |  0 |   Diffuse.B |  0 | SpecularStr |  3
+    /// 1 (+ 4) |   Specular.R |  1 |   Specular.G |  1 |  Specular.B |  1 |       Gloss |  4
+    /// 2 (+ 8) |   Emissive.R |  2 |   Emissive.G |  2 |  Emissive.B |  2 |  Tile Index |
+    /// 7 (+28) |   Tile XF UU |    |   Tile XF UV |    |  Tile XF VU |    |  Tile XF VV |
+    /// </code>
+    /// </summary>
+    [InlineArray(NumVec4 * Halves)]
+    public struct Row : IEquatable<Row>
     {
-        public const int NumHalves = 16;
-        public const int Size      = NumHalves * 2;
+        public const int NumVec4 = 4;
+        public const int Halves  = 4;
+        public const int Size    = NumVec4 * Halves * 2;
 
-        private fixed ushort _data[NumHalves];
+        [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "InlineArray")]
+        private Half _element0;
 
         public static readonly Row Default = new()
         {
-            Diffuse          = Vector3.One,
-            Specular         = Vector3.One,
-            SpecularStrength = 1.0f,
-            Emissive         = Vector3.Zero,
-            GlossStrength    = 20.0f,
-            TileSet          = 0,
-            MaterialRepeat   = new Vector2(16.0f),
-            MaterialSkew     = Vector2.Zero,
+            DiffuseColor  = HalfColor.White,
+            SpecularMask  = Half.One,
+            SpecularColor = HalfColor.White,
+            Shininess     = (Half)20.0f,
+            EmissiveColor = HalfColor.Black,
+            TileIndex     = 0,
+            TileTransform = HalfMatrix2x2.ScaledIdentity((Half)16.0f),
         };
 
-        public Vector3 Diffuse
+        public HalfColor DiffuseColor
         {
-            readonly get => new(ToFloat(0), ToFloat(1), ToFloat(2));
+            readonly get => new(this[0], this[1], this[2]);
             set
             {
-                _data[0] = FromFloat(value.X);
-                _data[1] = FromFloat(value.Y);
-                _data[2] = FromFloat(value.Z);
+                this[0] = value.Red;
+                this[1] = value.Green;
+                this[2] = value.Blue;
             }
         }
 
-        public Vector3 Specular
+        public Half SpecularMask
         {
-            readonly get => new(ToFloat(4), ToFloat(5), ToFloat(6));
+            readonly get => this[3];
+            set => this[3] = value;
+        }
+
+        public HalfColor SpecularColor
+        {
+            readonly get => new(this[4], this[5], this[6]);
             set
             {
-                _data[4] = FromFloat(value.X);
-                _data[5] = FromFloat(value.Y);
-                _data[6] = FromFloat(value.Z);
+                this[4] = value.Red;
+                this[5] = value.Green;
+                this[6] = value.Blue;
             }
         }
 
-        public Vector3 Emissive
+        public Half Shininess
         {
-            readonly get => new(ToFloat(8), ToFloat(9), ToFloat(10));
+            readonly get => this[7];
+            set => this[7] = value;
+        }
+
+        public HalfColor EmissiveColor
+        {
+            readonly get => new(this[8], this[9], this[10]);
             set
             {
-                _data[8]  = FromFloat(value.X);
-                _data[9]  = FromFloat(value.Y);
-                _data[10] = FromFloat(value.Z);
+                this[8]  = value.Red;
+                this[9]  = value.Green;
+                this[10] = value.Blue;
             }
         }
 
-        public Vector2 MaterialRepeat
+        public ushort TileIndex
         {
-            readonly get => new(ToFloat(12), ToFloat(15));
+            readonly get => (ushort)((float)this[11] * 64f);
+            set => this[11] = (Half)((value + 0.5f) / 64f);
+        }
+
+        public HalfMatrix2x2 TileTransform
+        {
+            readonly get => new(this[12], this[13], this[14], this[15]);
             set
             {
-                _data[12] = FromFloat(value.X);
-                _data[15] = FromFloat(value.Y);
+                this[12] = value.UU;
+                this[13] = value.UV;
+                this[14] = value.VV;
+                this[15] = value.VV;
             }
         }
 
-        public Vector2 MaterialSkew
-        {
-            readonly get => new(ToFloat(13), ToFloat(14));
-            set
-            {
-                _data[13] = FromFloat(value.X);
-                _data[14] = FromFloat(value.Y);
-            }
-        }
-
-        public float SpecularStrength
-        {
-            readonly get => ToFloat(3);
-            set => _data[3] = FromFloat(value);
-        }
-
-        public float GlossStrength
-        {
-            readonly get => ToFloat(7);
-            set => _data[7] = FromFloat(value);
-        }
-
-        public ushort TileSet
-        {
-            readonly get => (ushort)(ToFloat(11) * 64f);
-            set => _data[11] = FromFloat((value + 0.5f) / 64f);
-        }
-
-        public readonly Span<Half> AsHalves()
-        {
-            fixed (ushort* ptr = _data)
-            {
-                return new Span<Half>(ptr, NumHalves);
-            }
-        }
-
-        public bool ApplyDyeTemplate(LegacyColorDyeTable.Row dyeRow, StmFile.DyePack dyes)
+        public bool ApplyDye(LegacyColorDyeTable.Row dyeRow, LegacyDyePack dyes)
         {
             var ret = false;
 
-            if (dyeRow.Diffuse && Diffuse != dyes.Diffuse)
+            if (dyeRow.DiffuseColor && DiffuseColor != dyes.DiffuseColor)
             {
-                Diffuse = dyes.Diffuse;
-                ret     = true;
+                DiffuseColor = dyes.DiffuseColor;
+                ret          = true;
             }
 
-            if (dyeRow.Specular && Specular != dyes.Specular)
+            if (dyeRow.SpecularColor && SpecularColor != dyes.SpecularColor && dyes.SpecularColor != HalfColor.Black)
             {
-                Specular = dyes.Specular;
-                ret      = true;
-            }
-
-            if (dyeRow.SpecularStrength && SpecularStrength != dyes.SpecularPower)
-            {
-                SpecularStrength = dyes.SpecularPower;
-                ret              = true;
-            }
-
-            if (dyeRow.Emissive && Emissive != dyes.Emissive)
-            {
-                Emissive = dyes.Emissive;
-                ret      = true;
-            }
-
-            if (dyeRow.Gloss && GlossStrength != dyes.Gloss)
-            {
-                GlossStrength = dyes.Gloss;
+                SpecularColor = dyes.SpecularColor;
                 ret           = true;
+            }
+
+            if (dyeRow.EmissiveColor && EmissiveColor != dyes.EmissiveColor)
+            {
+                EmissiveColor = dyes.EmissiveColor;
+                ret           = true;
+            }
+
+            if (dyeRow.SpecularMask && SpecularMask != dyes.SpecularMask)
+            {
+                SpecularMask = dyes.SpecularMask;
+                ret          = true;
+            }
+
+            if (dyeRow.Shininess && Shininess != dyes.Shininess)
+            {
+                Shininess = dyes.Shininess;
+                ret       = true;
             }
 
             return ret;
         }
 
-        private readonly float ToFloat(int idx)
-            => (float)BitConverter.UInt16BitsToHalf(_data[idx]);
-
-        private static ushort FromFloat(float x)
-            => BitConverter.HalfToUInt16Bits((Half)x);
-
         public Row(in ColorTable.Row row)
         {
-            Diffuse          = row.Diffuse;
-            Specular         = row.Specular;
-            Emissive         = row.Emissive;
-            MaterialRepeat   = row.MaterialRepeat;
-            MaterialSkew     = row.MaterialSkew;
-            SpecularStrength = row.SpecularStrength;
-            GlossStrength    = row.GlossStrength;
-            TileSet          = row.TileSet;
+            DiffuseColor  = row.DiffuseColor;
+            SpecularMask  = row.Scalar7;
+            SpecularColor = row.SpecularColor;
+            Shininess     = row.Scalar3;
+            EmissiveColor = row.EmissiveColor;
+            TileIndex     = row.TileIndex;
+            TileTransform = row.TileTransform;
         }
+
+        public override readonly bool Equals([NotNullWhen(true)] object? obj)
+            => obj is Row other && Equals(other);
+
+        public readonly bool Equals(Row other)
+            => this[..].SequenceEqual(other[..]);
+
+        public override readonly int GetHashCode()
+        {
+            var hc = new HashCode();
+            hc.AddBytes(MemoryMarshal.AsBytes(new ReadOnlySpan<Row>(in this)));
+            return hc.ToHashCode();
+        }
+
+        public static bool operator ==(Row row1, Row row2)
+            => row1.Equals(row2);
+
+        public static bool operator !=(Row row1, Row row2)
+            => !row1.Equals(row2);
     }
 
-    public const  int  NumRows     = 16;
-    public const  int  NumUsedRows = 16;
-    public const  int  Size        = NumRows * Row.Size;
-    private fixed byte _rowData[Size];
+    [InlineArray(NumRows)]
+    private struct Table
+    {
+        [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "InlineArray")]
+        private Row _element0;
+    }
+
+    public const int NumRows = 16;
+    public const int Size    = NumRows * Row.Size;
+
+    int IColorTable.Width   => Row.NumVec4;
+    int IColorTable.RowSize => Row.Size;
+    int IColorTable.Height  => NumRows;
+    int IColorTable.Size    => Size;
+    byte IColorTable.DimensionLogs => 0;
+
+    private Table _rowData;
 
     public ref Row this[int i]
-    {
-        get
-        {
-            fixed (byte* ptr = _rowData)
-            {
-                return ref ((Row*)ptr)[i];
-            }
-        }
-    }
+        => ref _rowData[i];
 
     public IEnumerator<Row> GetEnumerator()
     {
         for (var i = 0; i < NumRows; ++i)
-            yield return this[i];
+            yield return _rowData[i];
     }
 
     IEnumerator IEnumerable.GetEnumerator()
         => GetEnumerator();
 
-    public readonly ReadOnlySpan<byte> AsBytes()
-    {
-        fixed (byte* ptr = _rowData)
-        {
-            return new ReadOnlySpan<byte>(ptr, Size);
-        }
-    }
+    public Span<byte> AsBytes()
+        => MemoryMarshal.AsBytes(_rowData[..]);
 
-    public readonly Span<Half> AsHalves()
-    {
-        fixed (byte* ptr = _rowData)
-        {
-            return new Span<Half>((Half*)ptr, NumRows * 16);
-        }
-    }
+    public Span<Half> AsHalves()
+        => MemoryMarshal.Cast<Row, Half>(_rowData);
 
-    public void SetDefault()
+    public Span<byte> RowAsBytes(int i)
+        => MemoryMarshal.AsBytes(_rowData[i][..]);
+
+    public Span<Half> RowAsHalves(int i)
+        => _rowData[i];
+
+    public Span<Row> AsRows()
+        => _rowData;
+
+    public bool SetDefault()
     {
+        var ret = false;
         for (var i = 0; i < NumRows; ++i)
-            this[i] = Row.Default;
+            ret |= SetDefaultRow(i);
+
+        return ret;
     }
 
-    public LegacyColorTable(in ColorTable newTable)
+    public bool SetDefaultRow(int i)
+    {
+        if (_rowData[i] == Row.Default)
+            return false;
+
+        _rowData[i] = Row.Default;
+        return true;
+    }
+
+    public bool ApplyDye(StmFile<LegacyDyePack> stm, ReadOnlySpan<StainId> stainIds, LegacyColorDyeTable dyeTable)
+    {
+        if (stainIds.Length == 0)
+            return false;
+
+        var ret = false;
+        for (var rowIdx = 0; rowIdx < LegacyColorDyeTable.NumRows; ++rowIdx)
+        {
+            var dyeRow = dyeTable[rowIdx];
+            if (stainIds[0] != 0 && stm.TryGetValue(dyeRow.Template, stainIds[0], out var dyes))
+                ret |= _rowData[rowIdx].ApplyDye(dyeRow, dyes);
+        }
+
+        return ret;
+    }
+
+    public bool ApplyDyeToRow(StmFile<LegacyDyePack> stm, ReadOnlySpan<StainId> stainIds, int rowIdx, LegacyColorDyeTable.Row dyeRow)
+    {
+        if (rowIdx < 0 || rowIdx >= NumRows || stainIds.Length == 0)
+            return false;
+
+        var ret = false;
+        if (stainIds[0] != 0 && stm.TryGetValue(dyeRow.Template, stainIds[0], out var dyes))
+            ret |= _rowData[rowIdx].ApplyDye(dyeRow, dyes);
+
+        return ret;
+    }
+
+    public LegacyColorTable()
+    {
+        SetDefault();
+    }
+
+    private LegacyColorTable(ref SpanBinaryReader reader)
+    {
+        _rowData = reader.Read<Table>();
+    }
+
+    public LegacyColorTable(ColorTable newTable)
     {
         for (var i = 0; i < NumRows; ++i)
             this[i] = new Row(newTable[i]);
     }
+
+    public LegacyColorTable(IColorTable other)
+    {
+        if (other is ColorTable newTable)
+        {
+            for (var i = 0; i < NumRows; ++i)
+                _rowData[i] = new Row(newTable[i]);
+        }
+        else if (other is LegacyColorTable table)
+        {
+            for (var i = 0; i < NumRows; ++i)
+                _rowData[i] = table[i];
+        }
+        else
+            SetDefault();
+    }
+
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+        for (var i = 0; i < NumRows; ++i)
+        {
+            var row = this[i];
+            for (var j = 0; j < Row.NumVec4 * Row.Halves; ++j)
+                sb.Append($"{row[j]:F1} ");
+            sb[^1] = '\n';
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Attempts to read a legacy color table from the given reader.
+    /// If the reader doesn't hold enough data, nothing will be read, and this will return a default table.
+    /// </summary>
+    public static LegacyColorTable TryReadFrom(ref SpanBinaryReader reader)
+        => reader.Remaining >= Size ? new(ref reader) : new();
 }

--- a/Files/MaterialStructs/OpaqueColorDyeTable.cs
+++ b/Files/MaterialStructs/OpaqueColorDyeTable.cs
@@ -1,0 +1,60 @@
+using Penumbra.GameData.Files.Utility;
+
+namespace Penumbra.GameData.Files.MaterialStructs;
+
+/// <summary>
+/// A color dye table of yet unknown structure.
+/// It will be read and written as-is, for round-trip I/O, but can only be further manipulated manually.
+/// </summary>
+internal sealed class OpaqueColorDyeTable : IColorDyeTable
+{
+    public readonly byte   HeightLog;
+    public readonly byte[] Data;
+
+    public unsafe int RowSize
+        => Data.Length / Height;
+
+    public int Height
+        => 1 << HeightLog;
+
+    public unsafe int Size
+        => Data.Length;
+
+    public OpaqueColorDyeTable(byte heightLog, int size)
+    {
+        HeightLog = heightLog;
+        Data      = new byte[size];
+    }
+
+    public unsafe OpaqueColorDyeTable(IColorDyeTable other)
+    {
+        HeightLog = (byte)BitOperations.Log2((uint)other.Height);
+        if (other.Height != Height)
+            throw new ArgumentException($"The source color dye table must have a power of 2 of rows.");
+        Data = new byte[other.Size];
+        other.AsBytes().CopyTo(AsBytes());
+    }
+
+    public Span<byte> AsBytes()
+        => MemoryMarshal.AsBytes(Data.AsSpan());
+
+    public Span<byte> RowAsBytes(int i)
+        => AsBytes()[(i * RowSize)..((i + 1) * RowSize)];
+
+    public bool SetDefault()
+        => throw new NotSupportedException();
+
+    public bool SetDefaultRow(int i)
+        => throw new NotSupportedException();
+
+    /// <summary>
+    /// Attempts to read a color dye table from the given reader.
+    /// </summary>
+    public static OpaqueColorDyeTable TryReadFrom(byte heightLog, ref SpanBinaryReader reader)
+    {
+        var table = new OpaqueColorDyeTable(heightLog, reader.Remaining);
+        reader.Read<byte>(table.Data.Length).CopyTo(table.Data);
+
+        return table;
+    }
+}

--- a/Files/MaterialStructs/OpaqueColorTable.cs
+++ b/Files/MaterialStructs/OpaqueColorTable.cs
@@ -1,0 +1,85 @@
+using Penumbra.GameData.Files.Utility;
+
+namespace Penumbra.GameData.Files.MaterialStructs;
+
+/// <summary>
+/// A color table of yet unknown structure.
+/// It will be read and written as-is, for round-trip I/O, but can only be further manipulated manually.
+/// </summary>
+internal sealed class OpaqueColorTable : IColorTable
+{
+    public readonly byte   DimensionLogs;
+    public readonly Half[] Data;
+
+    public int Width
+        => 1 << (DimensionLogs & 0xF);
+
+    public int RowSize
+        => 8 * Width;
+
+    public int Height
+        => 1 << (DimensionLogs >> 4);
+
+    public int Size
+        => 2 * Data.Length;
+
+    byte IColorTable.DimensionLogs => DimensionLogs;
+
+    public OpaqueColorTable(byte dimensionLogs)
+    {
+        DimensionLogs = dimensionLogs;
+        Data          = new Half[4 * Width * Height];
+    }
+
+    public OpaqueColorTable(IColorTable other)
+    {
+        DimensionLogs = other.DimensionLogs;
+        Data          = new Half[4 * Width * Height];
+        other.AsHalves().CopyTo(Data);
+    }
+
+    public Span<byte> AsBytes()
+        => MemoryMarshal.AsBytes(Data.AsSpan());
+
+    public Span<Half> AsHalves()
+        => Data;
+
+    public Span<byte> RowAsBytes(int i)
+        => MemoryMarshal.AsBytes(RowAsHalves(i));
+
+    public Span<Half> RowAsHalves(int i)
+        => Data.AsSpan(i).Slice(Width * i, Width);
+
+    public bool SetDefault()
+        => throw new NotSupportedException();
+
+    public bool SetDefaultRow(int i)
+        => throw new NotSupportedException();
+
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+        for (var i = 0; i < Height; ++i)
+        {
+            var row = RowAsHalves(i);
+            for (var j = 0; j < Width; ++j)
+                sb.Append($"{row[j]:F1} ");
+            sb[^1] = '\n';
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Attempts to read a color table of the given dimensions from the given reader.
+    /// If the reader doesn't hold enough data, nothing will be read, and this will return an all-zero table.
+    /// </summary>
+    public static OpaqueColorTable TryReadFrom(byte dimensionLogs, ref SpanBinaryReader reader)
+    {
+        var table = new OpaqueColorTable(dimensionLogs);
+        if (reader.Remaining >= table.Size)
+            reader.Read<Half>(table.Data.Length).CopyTo(table.Data);
+
+        return table;
+    }
+}

--- a/Files/MaterialStructs/SamplerFlags.cs
+++ b/Files/MaterialStructs/SamplerFlags.cs
@@ -1,0 +1,58 @@
+namespace Penumbra.GameData.Files.MaterialStructs;
+
+[StructLayout(LayoutKind.Sequential)]
+public struct SamplerFlags(uint flags) : IEquatable<SamplerFlags>
+{
+    public uint Flags = flags;
+
+    public TextureAddressMode UAddressMode
+    {
+        readonly get => (TextureAddressMode)(Flags & 0x3u);
+        set => Flags = (Flags & ~0x3u) | ((uint)value & 0x3u);
+    }
+
+    public TextureAddressMode VAddressMode
+    {
+        readonly get => (TextureAddressMode)((Flags >> 2) & 0x3u);
+        set => Flags = (Flags & ~0xCu) | (((uint)value & 0x3u) << 2);
+    }
+
+    public float LodBias
+    {
+        readonly get => unchecked((int)(Flags << 12) >> 22) / 64.0f;
+        set => Flags = (Flags & ~0x000FFC00u)
+              | ((uint)((int)Math.Round(Math.Clamp(value, -8.0f, 7.984375f) * 64.0f) & 0x3FF) << 10);
+    }
+
+    public int MinLod
+    {
+        readonly get => (int)((Flags >> 20) & 0xFu);
+        set => Flags = (Flags & ~0x00F00000u) | ((uint)Math.Clamp(value, 0, 15) << 20);
+    }
+
+    public override readonly bool Equals([NotNullWhen(true)] object? obj)
+        => obj is SamplerFlags other && Flags == other.Flags;
+
+    public readonly bool Equals(SamplerFlags other)
+        => Flags == other.Flags;
+
+    public override readonly int GetHashCode()
+        => Flags.GetHashCode();
+
+    public static ref SamplerFlags Wrap(ref uint flags)
+        => ref UtilityFunctions.Cast<uint, SamplerFlags>(ref flags);
+
+    public static bool operator ==(SamplerFlags left, SamplerFlags right)
+        => left.Flags == right.Flags;
+
+    public static bool operator !=(SamplerFlags left, SamplerFlags right)
+        => left.Flags != right.Flags;
+
+    public enum TextureAddressMode : uint
+    {
+        Wrap   = 0,
+        Mirror = 1,
+        Clamp  = 2,
+        Border = 3,
+    }
+}

--- a/Files/MaterialStructs/ShaderFlags.cs
+++ b/Files/MaterialStructs/ShaderFlags.cs
@@ -1,0 +1,37 @@
+namespace Penumbra.GameData.Files.MaterialStructs;
+
+[StructLayout(LayoutKind.Sequential)]
+public struct ShaderFlags(uint flags) : IEquatable<ShaderFlags>
+{
+    public uint Flags = flags;
+
+    public bool HideBackfaces
+    {
+        readonly get => (Flags & 0x1u) != 0;
+        set => Flags = value ? (Flags | 0x1u) : (Flags & ~0x1u);
+    }
+
+    public bool EnableTransparency
+    {
+        readonly get => (Flags & 0x10u) != 0;
+        set => Flags = value ? (Flags | 0x10u) : (Flags & ~0x10u);
+    }
+
+    public override readonly bool Equals([NotNullWhen(true)] object? obj)
+        => obj is ShaderFlags other && Flags == other.Flags;
+
+    public readonly bool Equals(ShaderFlags other)
+        => Flags == other.Flags;
+
+    public override readonly int GetHashCode()
+        => Flags.GetHashCode();
+
+    public static ref ShaderFlags Wrap(ref uint flags)
+        => ref UtilityFunctions.Cast<uint, ShaderFlags>(ref flags);
+
+    public static bool operator ==(ShaderFlags left, ShaderFlags right)
+        => left.Flags == right.Flags;
+
+    public static bool operator !=(ShaderFlags left, ShaderFlags right)
+        => left.Flags != right.Flags;
+}

--- a/Files/MaterialStructs/TableFlags.cs
+++ b/Files/MaterialStructs/TableFlags.cs
@@ -1,0 +1,59 @@
+namespace Penumbra.GameData.Files.MaterialStructs;
+
+[StructLayout(LayoutKind.Sequential)]
+public struct TableFlags(uint flags) : IEquatable<TableFlags>
+{
+    public uint Flags = flags;
+
+    public bool HasTable
+    {
+        readonly get => (Flags & 0x4u) != 0;
+        set => Flags = value ? (Flags | 0x4u) : (Flags & ~0x4u);
+    }
+
+    public bool HasDyeTable
+    {
+        readonly get => (Flags & 0x8u) != 0;
+        set => Flags = value ? (Flags | 0x8u) : (Flags & ~0x8u);
+    }
+
+    // We have no reasonably simple way to determine for sure whether a material without a color table is a legacy or DT one.
+    public readonly bool IsDawntrail
+        => !HasTable || TableWidthLog != 0 && TableHeightLog != 0;
+
+    public byte TableWidthLog
+    {
+        readonly get => (byte)((Flags >> 4) & 0xFu);
+        set => Flags = (Flags & ~0xF0u) | ((value & 0xFu) << 4);
+    }
+
+    public byte TableHeightLog
+    {
+        readonly get => (byte)((Flags >> 8) & 0xFu);
+        set => Flags = (Flags & ~0xF00u) | ((value & 0xFu) << 8);
+    }
+
+    public byte TableDimensionLogs
+    {
+        readonly get => unchecked((byte)(Flags >> 4));
+        set => Flags = (Flags & ~0xFF0u) | ((uint)value << 4);
+    }
+
+    public override readonly bool Equals([NotNullWhen(true)] object? obj)
+        => obj is TableFlags other && Flags == other.Flags;
+
+    public readonly bool Equals(TableFlags other)
+        => Flags == other.Flags;
+
+    public override readonly int GetHashCode()
+        => Flags.GetHashCode();
+
+    public static ref TableFlags Wrap(ref uint flags)
+        => ref UtilityFunctions.Cast<uint, TableFlags>(ref flags);
+
+    public static bool operator ==(TableFlags left, TableFlags right)
+        => left.Flags == right.Flags;
+
+    public static bool operator !=(TableFlags left, TableFlags right)
+        => left.Flags != right.Flags;
+}

--- a/Files/MtrlFile.Write.cs
+++ b/Files/MtrlFile.Write.cs
@@ -1,4 +1,3 @@
-using Penumbra.GameData.Files.MaterialStructs;
 using Penumbra.GameData.Files.Utility;
 
 namespace Penumbra.GameData.Files;
@@ -7,6 +6,8 @@ public partial class MtrlFile
 {
     public byte[] Write()
     {
+        UpdateFlags();
+
         using var stream  = new MemoryStream();
         using var strings = new StringPool();
         using (var w = new BinaryWriter(stream))
@@ -38,41 +39,21 @@ public partial class MtrlFile
 
             w.Write(AdditionalData);
             var dataSetSize = 0;
-            if (HasTable)
+            if (Table != null)
             {
-                if (IsDawnTrail)
-                {
-                    var span = Table.AsBytes();
-                    w.Write(span);
-                    dataSetSize += span.Length;
-                }
-                else
-                {
-                    var table = new LegacyColorTable(Table);
-                    var span  = table.AsBytes();
-                    w.Write(span);
-                    dataSetSize += span.Length;
-                }
+                var span = Table.AsBytes();
+                w.Write(span);
+                dataSetSize += span.Length;
             }
 
-            if (HasTable && HasDyeTable)
+            if (Table != null && DyeTable != null)
             {
-                if (IsDawnTrail)
-                {
-                    var span = DyeTable.AsBytes();
-                    w.Write(span);
-                    dataSetSize += span.Length;
-                }
-                else
-                {
-                    var table = new LegacyColorDyeTable(DyeTable);
-                    var span  = table.AsBytes();
-                    w.Write(span);
-                    dataSetSize += span.Length;
-                }
+                var span = DyeTable.AsBytes();
+                w.Write(span);
+                dataSetSize += span.Length;
             }
 
-            w.Write((ushort)(ShaderPackage.ShaderValues.Length * 4));
+            w.Write((ushort)ShaderPackage.ShaderValues.Length);
             w.Write((ushort)ShaderPackage.ShaderKeys.Length);
             w.Write((ushort)ShaderPackage.Constants.Length);
             w.Write((ushort)ShaderPackage.Samplers.Length);
@@ -100,8 +81,7 @@ public partial class MtrlFile
                 w.Write((byte)0);
             }
 
-            foreach (var value in ShaderPackage.ShaderValues)
-                w.Write(value);
+            w.Write(ShaderPackage.ShaderValues);
 
             WriteHeader(w, (ushort)w.BaseStream.Position, dataSetSize, (ushort)strings.Length, shaderPackageNameOffset);
         }

--- a/Files/ShaderStructs/Name.cs
+++ b/Files/ShaderStructs/Name.cs
@@ -1,0 +1,92 @@
+namespace Penumbra.GameData.Files.ShaderStructs;
+
+/// <summary>
+/// Represents a shader resource (constant, sampler, texture, material parameter, ...) CRC32 identifier, along with the corresponding name if it is known.
+/// </summary>
+/// <remarks>
+/// The name is used only for user interface purposes, and purposely omitted from comparisons and related operations.
+/// </remarks>
+public readonly struct Name : IEquatable<Name>, IComparable<Name>
+{
+    public const string UnknownPrefix = "\uFFFD";
+
+    public static readonly Name Empty = new(string.Empty);
+
+    public readonly string? Value;
+    public readonly uint    Crc32;
+
+    public bool IsValueAuthoritative
+        => Value != null && Crc32 == Lumina.Misc.Crc32.Get(Value, 0xFFFFFFFFu);
+
+    public Name(uint crc32)
+    {
+        Crc32 = crc32;
+        Value = null;
+    }
+
+    public Name(string value)
+    {
+        Crc32 = Lumina.Misc.Crc32.Get(value, 0xFFFFFFFFu);
+        Value = value;
+    }
+
+    public Name(ReadOnlySpan<byte> value)
+    {
+        Crc32 = Lumina.Misc.Crc32.Get(value, 0xFFFFFFFFu);
+        Value = Encoding.UTF8.GetString(value);
+    }
+
+    public Name(uint crc32, string? value)
+    {
+        Crc32 = crc32;
+        Value = value;
+    }
+
+    public bool Equals(Name other)
+        => Crc32 == other.Crc32;
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+        => obj is Name other && Equals(other);
+
+    public int CompareTo(Name other)
+        => Crc32.CompareTo(other.Crc32);
+
+    public override int GetHashCode()
+        => unchecked((int)Crc32);
+
+    public override string ToString()
+        => Value ?? $"0x{Crc32:X8}";
+
+    public static implicit operator Name(uint crc32)
+        => new(crc32);
+
+    public static implicit operator Name(string value)
+        => new(value);
+
+    public static implicit operator Name(ReadOnlySpan<byte> value)
+        => new(value);
+
+    public static bool operator ==(Name left, Name right)
+        => left.Equals(right);
+
+    public static bool operator !=(Name left, Name right)
+        => !left.Equals(right);
+
+    public static bool operator <(Name left, Name right)
+        => left.CompareTo(right) < 0;
+
+    public static bool operator <=(Name left, Name right)
+        => left.CompareTo(right) <= 0;
+
+    public static bool operator >(Name left, Name right)
+        => left.CompareTo(right) > 0;
+
+    public static bool operator >=(Name left, Name right)
+        => left.CompareTo(right) >= 0;
+
+    public static Name operator +(Name left, string right)
+        => new(Lumina.Misc.Crc32.Get(right, ~left.Crc32), (left.Value ?? UnknownPrefix) + right);
+
+    public static Name operator +(Name left, ReadOnlySpan<byte> right)
+        => new(Lumina.Misc.Crc32.Get(right, ~left.Crc32), (left.Value ?? UnknownPrefix) + Encoding.UTF8.GetString(right));
+}

--- a/Files/ShaderStructs/Names.cs
+++ b/Files/ShaderStructs/Names.cs
@@ -1,0 +1,414 @@
+using System.Collections.Frozen;
+
+namespace Penumbra.GameData.Files.ShaderStructs;
+
+public static class Names
+{
+    public static readonly int                          LongestKnownNameLength;
+    public static readonly FrozenDictionary<uint, Name> KnownNames;
+    public static readonly int                          LongestKnownSuffixLength;
+    public static readonly FrozenSet<string>            KnownSuffixes;
+
+    public static readonly Name SphereMapIndexConstantName = "g_SphereMapIndex";
+    public static readonly Name TileIndexConstantName      = "g_TileIndex";
+
+    public static Name TryResolve(this IReadOnlyDictionary<uint, Name> dictionary, uint id)
+        => dictionary.TryGetValue(id, out var name) ? name : id;
+
+    public static Name TryResolve(this IReadOnlyDictionary<uint, Name> dictionary, IReadOnlyDictionary<uint, Name> fallbackDictionary, uint id)
+        => dictionary.TryGetValue(id, out var name) || fallbackDictionary.TryGetValue(id, out name) ? name : id;
+
+    public static IReadOnlyDictionary<uint, Name> WithKnownSuffixes(this Name baseName)
+    {
+        var stem = baseName;
+        if (baseName.IsValueAuthoritative && baseName.Value!.EndsWith("_Table"))
+        {
+            if (baseName.Value.StartsWith("UvCompute"))
+                stem = "UvCompute";
+            else if (baseName.Value.StartsWith("TextureDistortion_UvSet"))
+                stem = "TextureDistortion_UvSet";
+            else if (baseName.Value.EndsWith("_UvNo_Table"))
+                stem = baseName.Value[..^8];
+            else
+                stem = baseName.Value[..^6];
+        }
+
+        return KnownSuffixes.Select(suffix => stem + suffix).Indexed();
+    }
+
+    public static IReadOnlyDictionary<uint, Name> Indexed(this IEnumerable<Name> names)
+    {
+        // Not using LINQ's ToDictionary because it would throw on duplicate.
+        var dictionary = new Dictionary<uint, Name>();
+        foreach (var name in names)
+            dictionary.TryAdd(name.Crc32, name);
+        return dictionary;
+    }
+
+    static Names()
+    {
+        var names    = GetKnownNames();
+        var suffixes = GetKnownSuffixes();
+
+        LongestKnownNameLength   = names.Select(name => name.Value!.Length).Max();
+        KnownNames               = names.Indexed().ToFrozenDictionary();
+        LongestKnownSuffixLength = suffixes.Select(suffix => suffix.Length).Max();
+        KnownSuffixes            = suffixes.ToFrozenSet();
+    }
+
+    #region Dictionaries
+
+    private static IReadOnlyList<Name> GetKnownNames()
+        => [
+            // Shader resources - These are usually irrelevant because the SHPK supplies them.
+            ShpkFile.MaterialParamsConstantName,
+            ShpkFile.TableSamplerName,
+            ShpkFile.NormalSamplerName,
+            ShpkFile.IndexSamplerName,
+
+            // Special material constants
+            SphereMapIndexConstantName,
+            TileIndexConstantName,
+
+            // Material constants
+            "g_AlphaAperture",
+            "g_AlphaMultiParam",
+            "g_AlphaOffset",
+            "g_AlphaThreshold",
+            "g_AmbientOcclusionMask",
+            "g_AngleClip",
+            "g_BackScatterPower",
+            "g_Color",
+            "g_ColorUVScale",
+            "g_DetailColor",
+            "g_DetailColorUvScale",
+            "g_DetailID",
+            "g_DetailNormalScale",
+            "g_DiffuseColor",
+            "g_EmissiveColor",
+            "g_EnvMapPower",
+            "g_FarClip",
+            "g_Fresnel",
+            "g_FresnelValue0",
+            "g_FurLength",
+            "g_GlassIOR",
+            "g_Gradation",
+            "g_HairBackScatterRoughnessOffsetRate",
+            "g_HairScatterColorShift",
+            "g_HairSecondaryRoughnessOffsetRate",
+            "g_HairSpecularBackScatterShift",
+            "g_HairSpecularPrimaryShift",
+            "g_HairSpecularSecondaryShift",
+            "g_HeightMapScale",
+            "g_HeightScale",
+            "g_InclusionAperture",
+            "g_Intensity",
+            "g_IrisOptionColorRate",
+            "g_IrisRingColor",
+            "g_IrisRingEmissiveIntensity",
+            "g_IrisRingForceColor",
+            "g_IrisThickness",
+            "g_LayerColor",
+            "g_LayerDepth",
+            "g_LayerIrregularity",
+            "g_LayerScale",
+            "g_LayerVelocity",
+            "g_LightingType",
+            "g_LipFresnelValue0",
+            "g_LipRoughnessScale",
+            "g_LipShininess",
+            "g_MultiDetailColor",
+            "g_MultiDiffuseColor",
+            "g_MultiEmissiveColor",
+            "g_MultiHeightScale",
+            "g_MultiNormalScale",
+            "g_MultiSpecularColor",
+            "g_MultiSSAOMask",
+            "g_MultiWaveScale",
+            "g_MultiWhitecapDistortion",
+            "g_MultiWhitecapScale",
+            "g_NearClip",
+            "g_NormalScale",
+            "g_NormalScale1",
+            "g_NormalUVScale",
+            "g_OutlineColor",
+            "g_OutlineWidth",
+            "g_PrefersFailure",
+            "g_Ray",
+            "g_ReflectionPower",
+            "g_RefractionColor",
+            "g_ScatteringLevel",
+            "g_ShaderID",
+            "g_ShadowAlphaThreshold",
+            "g_ShadowOffset",
+            "g_ShadowPosOffset",
+            "g_SheenAperture",
+            "g_SheenRate",
+            "g_SheenTintRate",
+            "g_Shininess",
+            "g_SpecularColor",
+            "g_SpecularColorMask",
+            "g_SpecularMask",
+            "g_SpecularPower",
+            "g_SpecularUVScale",
+            "g_SSAOMask",
+            "g_SubSurfacePower",
+            "g_SubSurfaceProfileID",
+            "g_SubSurfaceWidth",
+            "g_TexAnim",
+            "g_TextureMipBias",
+            "g_TexU",
+            "g_TexV",
+            "g_TileAlpha",
+            "g_TileScale",
+            "g_ToonIndex",
+            "g_ToonLightScale",
+            "g_ToonReflectionScale",
+            "g_ToonSpecIndex",
+            "g_Transparency",
+            "g_TransparencyDistance",
+            "g_UseSubSurfaceRate",
+            "g_WaveletDistortion",
+            "g_WaveletNoiseParam",
+            "g_WaveletOffset",
+            "g_WaveletScale",
+            "g_WaveSpeed",
+            "g_WaveTime",
+            "g_WaveTime1",
+            "g_WhitecapColor",
+            "g_WhitecapDistance",
+            "g_WhitecapDistortion",
+            "g_WhitecapNoiseScale",
+            "g_WhitecapScale",
+            "g_WhitecapSpeed",
+            "g_WhiteEyeColor",
+
+            // Shader functions
+            "AddLayer",
+            "ApplyAttenuation",
+            "ApplyConeAttenuation",
+            "ApplyDitherClip",
+            "ApplyMaskTexture",
+            "ApplyOmniShadow",
+            "ApplyUnderWater",
+            "ApplyWavelet",
+            "ApplyWavingAnim",
+            "ApplyWavingAnimation",
+            "ComputeSoftParticleAlpha",
+            "DecodeDepthBuffer",
+            "GeometryInstancing",
+            "GetAmbientLight",
+            "GetAmbientOcclusion",
+            "GetColor",
+            "GetDecalColor",
+            "GetDirectionalLight",
+            "GetFakeSpecular",
+            "GetInstanceData",
+            "GetLocalPosition",
+            "GetMaterialValue",
+            "GetNormalMap",
+            "GetReflectColor",
+            "GetRLR",
+            "GetShadow",
+            "GetSubColor",
+            "GetUnderWaterLighting",
+            "GetValues",
+            "LightClip",
+            "SelectOutput",
+            "ShadowDistanceFadeType",
+            "ShadowSoftShadowType",
+            "SpecularLighting",
+            "TransformProj",
+            "TransformType",
+            "TransformView",
+            "Type",
+
+            // Shader tables
+            "ApplyFog_Table",
+            "ApplyLightBufferType_Table",
+            "ComputeFinalColorType_Table",
+            "ComputeSoftParticleType_Table",
+            "DepthOffsetType_Table",
+            "DirectionalLight_Table",
+            "DirectionalLightType_Table",
+            "ForceFarZ_Table",
+            "OutputType_Table",
+            "PointLightCount_Table",
+            "PointLightPositionType_Table",
+            "PointLightType_Table",
+            "TextureColor1_CalculateAlpha_Table",
+            "TextureColor1_CalculateColor_Table",
+            "TextureColor1_ColorToAlpha_Table",
+            "TextureColor1_Decode_Table",
+            "TextureColor1_Table",
+            "TextureColor1_UvNo_Table",
+            "TextureColor2_CalculateAlpha_Table",
+            "TextureColor2_CalculateColor_Table",
+            "TextureColor2_ColorToAlpha_Table",
+            "TextureColor2_Decode_Table",
+            "TextureColor2_Table",
+            "TextureColor2_UvNo_Table",
+            "TextureColor3_CalculateAlpha_Table",
+            "TextureColor3_CalculateColor_Table",
+            "TextureColor3_ColorToAlpha_Table",
+            "TextureColor3_Decode_Table",
+            "TextureColor3_Table",
+            "TextureColor3_UvNo_Table",
+            "TextureColor4_CalculateAlpha_Table",
+            "TextureColor4_CalculateColor_Table",
+            "TextureColor4_ColorToAlpha_Table",
+            "TextureColor4_Decode_Table",
+            "TextureColor4_Table",
+            "TextureColor4_UvNo_Table",
+            "TextureDistortion",
+            "TextureDistortion_UvNo_Table",
+            "TextureDistortion_UvSet0_Table",
+            "TextureDistortion_UvSet1_Table",
+            "TextureDistortion_UvSet2_Table",
+            "TextureDistortion_UvSet3_Table",
+            "TextureNormal_Table",
+            "TextureNormal_UvNo_Table",
+            "TexturePalette_Table",
+            "TextureReflection_CalculateColor_Table",
+            "TextureReflection_Table",
+            "UvCompute0_Table",
+            "UvCompute1_Table",
+            "UvCompute2_Table",
+            "UvCompute3_Table",
+            "UvPrecisionType_Table",
+            "UvSetCount_Table",
+
+            // Other shader keys
+            "Color",
+            "Default",
+            "DefaultTechnique",
+            "Depth",
+            "GeometryInstancingOff",
+            "GeometryInstancingOn",
+            "GetInstancingData_Bush",
+            "GetNoInstancingData_Bush",
+            "SUB_VIEW_CUBE_0",
+            "SUB_VIEW_MAIN",
+            "SUB_VIEW_ROOF",
+            "SUB_VIEW_SHADOW_0",
+            "SUB_VIEW_SHADOW_1",
+
+            // Rendering passes
+            "PASS_0",
+            "PASS_7",
+            "PASS_10",
+            "PASS_12",
+            "PASS_14",
+            "PASS_COMPOSITE_OPAQUE",
+            "PASS_COMPOSITE_SEMITRANSPARENCY",
+            "PASS_COMPOSITE_SEMITRANSPARENCY_UNDER_WATER",
+            "PASS_G_OPAQUE",
+            "PASS_G_SEMITRANSPARENCY",
+            "PASS_ID",
+            "PASS_LIGHTING_OPAQUE",
+            "PASS_LIGHTING_SEMITRANSPARENCY",
+            "PASS_SEMITRANSPARENCY",
+            "PASS_WATER",
+            "PASS_WATER_Z",
+            "PASS_WIREFRAME",
+            "PASS_Z_OPAQUE",
+        ];
+
+    private static IReadOnlyList<string> GetKnownSuffixes()
+        => [
+            // Shader functions
+            "0",
+            "1",
+            "2",
+            "Add",
+            "Alpha",
+            "Body",
+            "Box",
+            "Cascade",
+            "CascadeWith",
+            "CloudOnly",
+            "Color",
+            "Compatibility",
+            "Depth",
+            "Distance",
+            "Face",
+            "FaceEmissive",
+            "Hair",
+            "Low",
+            "Mask",
+            "Mul",
+            "None",
+            "Normal",
+            "Off",
+            "On",
+            "ParallaxOcclusion",
+            "Plane",
+            "PlaneFar",
+            "PlaneNear",
+            "ReflectivityRGB",
+            "RGBA",
+            "Rigid",
+            "Simple",
+            "Skin",
+            "TerrainEadg",
+            "WaterDepth",
+
+            // Shader tables
+            "_0",
+            "_0_0",
+            "_1",
+            "_1_0",
+            "_1_1",
+            "_1x1",
+            "_2",
+            "_3",
+            "_3x3",
+            "_4",
+            "_Add",
+            "_Alpha",
+            "_Apply",
+            "_AutoPlacement",
+            "_ByParameter",
+            "_ByPixelPosition",
+            "_Chara",
+            "_Color",
+            "_Cubic",
+            "_Debug",
+            "_Disable",
+            "_Enable",
+            "_Ex",
+            "_FixedIntervalNDC",
+            "_HalfLambert",
+            "_High",
+            "_INTZ_FETCH4",
+            "_Lambert",
+            "_Legacy",
+            "_LerpWhite",
+            "_Linear",
+            "_Low",
+            "_Map",
+            "_MapChara",
+            "_Max",
+            "_Medium",
+            "_Min",
+            "_ModulateAlpha",
+            "_Mul",
+            "_None",
+            "_NoneControl",
+            "_Nothing",
+            "_PerModel",
+            "_PerPixel",
+            "_Quadratic",
+            "_RAWZ",
+            "_Release",
+            "_RGB",
+            "_SH",
+            "_Shadow",
+            "_Shigemi",
+            "_Sub",
+            "_Table",
+            "_Texture",
+        ];
+
+    #endregion
+}

--- a/Files/ShpkFile.Shader.cs
+++ b/Files/ShpkFile.Shader.cs
@@ -1,6 +1,7 @@
 using FFXIVClientStructs.FFXIV.Client.Graphics.Kernel;
 using Lumina.Misc;
 using DisassembledShader = Penumbra.GameData.Interop.DisassembledShader;
+using ShaderKeyValueSet = Penumbra.GameData.Structs.SharedSet<uint, uint>;
 
 namespace Penumbra.GameData.Files;
 
@@ -21,6 +22,12 @@ public partial class ShpkFile
         public  byte[]                         AdditionalHeader;
         private byte[]                         _byteData;
         private DisassembledShader?            _disassembly;
+
+        public ShaderKeyValueSet[]? SystemValues;
+        public ShaderKeyValueSet[]? SceneValues;
+        public ShaderKeyValueSet[]? MaterialValues;
+        public ShaderKeyValueSet[]? SubViewValues;
+        public ShaderKeyValueSet    Passes;
 
         public byte[] Blob
         {
@@ -77,40 +84,40 @@ public partial class ShpkFile
         /// <remarks>
         /// This is only stored for vertex shaders.
         /// </remarks>
-        public VertexShader.Input DeclaredInputs
+        public readonly VertexShader.Input DeclaredInputs
             => (VertexShader.Input)(AdditionalHeader.Length >= 4 ? BitConverter.ToUInt32(AdditionalHeader, 0) : 0u);
 
         /// <remarks>
         /// This is only stored for Shader Model 5 (DirectX 11) vertex shaders.
         /// </remarks>
-        public VertexShader.Input UsedInputs
+        public readonly VertexShader.Input UsedInputs
             => (VertexShader.Input)(AdditionalHeader.Length >= 8 ? BitConverter.ToUInt32(AdditionalHeader, 4) : 0u);
 
-        public DisassembledShader? Disassembly
+        public readonly DisassembledShader? Disassembly
             => _disassembly;
 
-        public Resource? GetConstantById(uint id)
+        public readonly Resource? GetConstantById(uint id)
             => Constants.FirstOrNull(res => res.Id == id);
 
-        public Resource? GetConstantByName(string name)
+        public readonly Resource? GetConstantByName(string name)
             => Constants.FirstOrNull(res => res.Name == name);
 
-        public Resource? GetSamplerById(uint id)
+        public readonly Resource? GetSamplerById(uint id)
             => Samplers.FirstOrNull(s => s.Id == id);
 
-        public Resource? GetSamplerByName(string name)
+        public readonly Resource? GetSamplerByName(string name)
             => Samplers.FirstOrNull(s => s.Name == name);
 
-        public Resource? GetUavById(uint id)
+        public readonly Resource? GetUavById(uint id)
             => Uavs.FirstOrNull(u => u.Id == id);
 
-        public Resource? GetUavByName(string name)
+        public readonly Resource? GetUavByName(string name)
             => Uavs.FirstOrNull(u => u.Name == name);
 
-        public Resource? GetTextureById(uint id)
+        public readonly Resource? GetTextureById(uint id)
             => Textures.FirstOrNull(s => s.Id == id);
 
-        public Resource? GetTextureByName(string name)
+        public readonly Resource? GetTextureByName(string name)
             => Textures.FirstOrNull(s => s.Name == name);
 
         public void UpdateResources(ShpkFile file)

--- a/Files/StainMapStructs/DyePack.cs
+++ b/Files/StainMapStructs/DyePack.cs
@@ -6,11 +6,11 @@ namespace Penumbra.GameData.Files.StainMapStructs;
 /// All dye-able color set information for a row - GUD (Dawntrail) format.
 /// </summary>
 [StructLayout(LayoutKind.Sequential, Pack = 2)]
-public record struct DyePack : IDyePack<DyePack>
+public record struct DyePack : IDyePack
 {
     public const string DefaultStmPath = "chara/base_material/stainingtemplate_gud.stm";
 
-    static string IDyePack<DyePack>.DefaultStmPath => DefaultStmPath;
+    static string IDyePack.DefaultStmPath => DefaultStmPath;
 
     public   HalfColor DiffuseColor;
     public   HalfColor SpecularColor;
@@ -31,9 +31,9 @@ public record struct DyePack : IDyePack<DyePack>
         set => RawSphereMapIndex = (Half)value;
     }
 
-    readonly HalfColor IDyePack<DyePack>.DiffuseColor  => DiffuseColor;
-    readonly HalfColor IDyePack<DyePack>.SpecularColor => SpecularColor;
-    readonly HalfColor IDyePack<DyePack>.EmissiveColor => EmissiveColor;
+    readonly HalfColor IDyePack.DiffuseColor  => DiffuseColor;
+    readonly HalfColor IDyePack.SpecularColor => SpecularColor;
+    readonly HalfColor IDyePack.EmissiveColor => EmissiveColor;
 
     public static int ColorCount  => 3;
     public static int ScalarCount => 9;

--- a/Files/StainMapStructs/DyePack.cs
+++ b/Files/StainMapStructs/DyePack.cs
@@ -1,0 +1,40 @@
+using Penumbra.GameData.Structs;
+
+namespace Penumbra.GameData.Files.StainMapStructs;
+
+/// <summary>
+/// All dye-able color set information for a row - GUD (Dawntrail) format.
+/// </summary>
+[StructLayout(LayoutKind.Sequential, Pack = 2)]
+public record struct DyePack : IDyePack<DyePack>
+{
+    public const string DefaultStmPath = "chara/base_material/stainingtemplate_gud.stm";
+
+    static string IDyePack<DyePack>.DefaultStmPath => DefaultStmPath;
+
+    public   HalfColor DiffuseColor;
+    public   HalfColor SpecularColor;
+    public   HalfColor EmissiveColor;
+    public   Half      Scalar3;
+    public   Half      Metalness;
+    public   Half      Roughness;
+    public   Half      SheenRate;
+    public   Half      SheenTintRate;
+    public   Half      SheenAperture;
+    public   Half      Anisotropy;
+    internal Half      RawSphereMapIndex;
+    public   Half      SphereMapMask;
+
+    public ushort SphereMapIndex
+    {
+        readonly get => (ushort)RawSphereMapIndex;
+        set => RawSphereMapIndex = (Half)value;
+    }
+
+    readonly HalfColor IDyePack<DyePack>.DiffuseColor  => DiffuseColor;
+    readonly HalfColor IDyePack<DyePack>.SpecularColor => SpecularColor;
+    readonly HalfColor IDyePack<DyePack>.EmissiveColor => EmissiveColor;
+
+    public static int ColorCount  => 3;
+    public static int ScalarCount => 9;
+}

--- a/Files/StainMapStructs/IDyePack.cs
+++ b/Files/StainMapStructs/IDyePack.cs
@@ -2,7 +2,7 @@ using Penumbra.GameData.Structs;
 
 namespace Penumbra.GameData.Files.StainMapStructs;
 
-public interface IDyePack<TDyePack> where TDyePack : unmanaged, IDyePack<TDyePack>
+public interface IDyePack
 {
     HalfColor DiffuseColor  { get; }
     HalfColor SpecularColor { get; }

--- a/Files/StainMapStructs/IDyePack.cs
+++ b/Files/StainMapStructs/IDyePack.cs
@@ -1,0 +1,14 @@
+using Penumbra.GameData.Structs;
+
+namespace Penumbra.GameData.Files.StainMapStructs;
+
+public interface IDyePack<TDyePack> where TDyePack : unmanaged, IDyePack<TDyePack>
+{
+    HalfColor DiffuseColor  { get; }
+    HalfColor SpecularColor { get; }
+    HalfColor EmissiveColor { get; }
+
+    abstract static string DefaultStmPath { get; }
+    abstract static int    ColorCount     { get; }
+    abstract static int    ScalarCount    { get; }
+}

--- a/Files/StainMapStructs/LegacyDyePack.cs
+++ b/Files/StainMapStructs/LegacyDyePack.cs
@@ -1,0 +1,27 @@
+using Penumbra.GameData.Structs;
+
+namespace Penumbra.GameData.Files.StainMapStructs;
+
+/// <summary>
+/// All dye-able color set information for a row - legacy format.
+/// </summary>
+[StructLayout(LayoutKind.Sequential, Pack = 2)]
+public record struct LegacyDyePack : IDyePack<LegacyDyePack>
+{
+    public const string DefaultStmPath = "chara/base_material/stainingtemplate.stm";
+
+    static string IDyePack<LegacyDyePack>.DefaultStmPath => DefaultStmPath;
+
+    public HalfColor DiffuseColor;
+    public HalfColor SpecularColor;
+    public HalfColor EmissiveColor;
+    public Half      Shininess;
+    public Half      SpecularMask;
+
+    readonly HalfColor IDyePack<LegacyDyePack>.DiffuseColor  => DiffuseColor;
+    readonly HalfColor IDyePack<LegacyDyePack>.SpecularColor => SpecularColor;
+    readonly HalfColor IDyePack<LegacyDyePack>.EmissiveColor => EmissiveColor;
+
+    public static int ColorCount  => 3;
+    public static int ScalarCount => 2;
+}

--- a/Files/StainMapStructs/LegacyDyePack.cs
+++ b/Files/StainMapStructs/LegacyDyePack.cs
@@ -6,11 +6,11 @@ namespace Penumbra.GameData.Files.StainMapStructs;
 /// All dye-able color set information for a row - legacy format.
 /// </summary>
 [StructLayout(LayoutKind.Sequential, Pack = 2)]
-public record struct LegacyDyePack : IDyePack<LegacyDyePack>
+public record struct LegacyDyePack : IDyePack
 {
     public const string DefaultStmPath = "chara/base_material/stainingtemplate.stm";
 
-    static string IDyePack<LegacyDyePack>.DefaultStmPath => DefaultStmPath;
+    static string IDyePack.DefaultStmPath => DefaultStmPath;
 
     public HalfColor DiffuseColor;
     public HalfColor SpecularColor;
@@ -18,9 +18,9 @@ public record struct LegacyDyePack : IDyePack<LegacyDyePack>
     public Half      Shininess;
     public Half      SpecularMask;
 
-    readonly HalfColor IDyePack<LegacyDyePack>.DiffuseColor  => DiffuseColor;
-    readonly HalfColor IDyePack<LegacyDyePack>.SpecularColor => SpecularColor;
-    readonly HalfColor IDyePack<LegacyDyePack>.EmissiveColor => EmissiveColor;
+    readonly HalfColor IDyePack.DiffuseColor  => DiffuseColor;
+    readonly HalfColor IDyePack.SpecularColor => SpecularColor;
+    readonly HalfColor IDyePack.EmissiveColor => EmissiveColor;
 
     public static int ColorCount  => 3;
     public static int ScalarCount => 2;

--- a/Files/StmFile.cs
+++ b/Files/StmFile.cs
@@ -1,23 +1,14 @@
 using Dalamud.Plugin.Services;
+using Penumbra.GameData.Files.StainMapStructs;
+using Penumbra.GameData.Files.Utility;
 using Penumbra.GameData.Structs;
 
 namespace Penumbra.GameData.Files;
 
-public partial class StmFile
+public partial class StmFile<TDyePack> where TDyePack : unmanaged, IDyePack<TDyePack>
 {
-    public const string Path = "chara/base_material/stainingtemplate.stm";
-
-    /// <summary>
-    /// All dye-able color set information for a row.
-    /// </summary>
-    public record struct DyePack
-    {
-        public Vector3 Diffuse;
-        public Vector3 Specular;
-        public Vector3 Emissive;
-        public float   Gloss;
-        public float   SpecularPower;
-    }
+    public const string LegacyPath = LegacyDyePack.DefaultStmPath;
+    public const string GudPath    = DyePack.DefaultStmPath;
 
     /// <summary>
     /// All currently available dyeing templates with their IDs.
@@ -30,11 +21,11 @@ public partial class StmFile
     /// <param name="template">The ID of the accessed template.</param>
     /// <param name="idx">The ID of the Stain.</param>
     /// <returns>The corresponding color set information or a defaulted DyePack of 0-entries.</returns>
-    public DyePack this[ushort template, int idx]
+    public TDyePack this[ushort template, int idx]
         => Entries.TryGetValue(template, out var entry) ? entry[idx] : default;
 
     /// <inheritdoc cref="this[ushort, StainId]"/>
-    public DyePack this[ushort template, StainId idx]
+    public TDyePack this[ushort template, StainId idx]
         => this[template, (int)idx.Id];
 
     /// <summary>
@@ -44,7 +35,7 @@ public partial class StmFile
     /// <param name="idx">The ID of the Stain.</param>
     /// <param name="dyes">On success, the corresponding color set information, otherwise a defaulted DyePack.</param>
     /// <returns>True on success, false otherwise.</returns>
-    public bool TryGetValue(ushort template, StainId idx, out DyePack dyes)
+    public bool TryGetValue(ushort template, StainId idx, out TDyePack dyes)
     {
         if (idx.Id is > 0 and <= StainingTemplateEntry.NumElements && Entries.TryGetValue(template, out var entry))
         {
@@ -56,39 +47,64 @@ public partial class StmFile
         return false;
     }
 
+    /// <inheritdoc cref="TryGetValue(ushort, StainId, out TDyePack)"/>
+    /// <returns>On success, the corresponding color set information, otherwise null.</returns>
+    public TDyePack? GetValueOrNull(ushort template, StainId idx)
+        => TryGetValue(template, idx, out var dyes) ? dyes : null;
+
     /// <summary>
     /// Create an STM file from the given data array.
     /// </summary>
-    public StmFile(byte[] data)
+    public StmFile(byte[] data) : this(data.AsSpan())
+    { }
+
+    public unsafe StmFile(ReadOnlySpan<byte> data)
     {
-        using var stream = new MemoryStream(data);
-        using var br     = new BinaryReader(stream);
-        br.ReadUInt32();
-        var numEntries = br.ReadInt32();
+        var br = new SpanBinaryReader(data);
+        var magic = br.ReadUInt16();
+        if (magic != 0x534D)
+            throw new InvalidDataException($"Invalid STM magic number 0x{magic:X4}");
+        var version    = br.ReadUInt16();
+        var numEntries = br.ReadUInt16();
+        var numColors  = br.ReadByte();
+        var numScalars = br.ReadByte();
 
-        var keys    = new ushort[numEntries];
-        var offsets = new ushort[numEntries];
+        if (version == 0x0101)
+        {
+            if (numColors != 0 || numScalars != 0)
+                throw new InvalidDataException($"Unexpected column counts in STM v1.1 file: {numColors} colors, {numScalars} scalars");
+            numColors  = 3;
+            numScalars = 2;
+        }
+        else if (version != 0x0200)
+            throw new InvalidDataException($"Unrecognized STM version v{version >> 2}.{version & 0xFF}");
 
-        for (var i = 0; i < numEntries; ++i)
-            keys[i] = br.ReadUInt16();
+        if (numColors != TDyePack.ColorCount || numScalars != TDyePack.ScalarCount)
+            throw new InvalidDataException($"Dye pack type {typeof(TDyePack)} expects STM file to have {TDyePack.ColorCount} colors and {TDyePack.ScalarCount} scalars per row, got file with {numColors} colors and {numScalars} scalars");
 
-        for (var i = 0; i < numEntries; ++i)
-            offsets[i] = br.ReadUInt16();
+        if (numColors * 6 + numScalars * 2 != sizeof(TDyePack))
+            throw new InvalidOperationException($"Dye pack type {typeof(TDyePack)} has a size of {sizeof(TDyePack)} bytes, but expects {numColors} colors and {numScalars} scalars, that is {numColors * 6 + numScalars * 2} bytes");
+
+        var keys    = br.Read<ushort>(numEntries);
+        var offsets = br.Read<ushort>(numEntries); // in ushorts/halves
+
+        var lengths = new int[numEntries]; // in bytes
+        for (var i = 1; i < numEntries; ++i)
+            lengths[i - 1] = (offsets[i] - offsets[i - 1]) << 1;
+        lengths[numEntries - 1] = br.Remaining - (offsets[numEntries - 1] << 1);
 
         var entries = new Dictionary<ushort, StainingTemplateEntry>(numEntries);
         Entries = entries;
 
+        br.SliceFromHere(offsets[0]);
         for (var i = 0; i < numEntries; ++i)
-        {
-            var offset = offsets[i] * 2 + 8 + 4 * numEntries;
-            entries.Add(keys[i], new StainingTemplateEntry(br, offset));
-        }
+            entries.Add(keys[i], new StainingTemplateEntry(br.SliceFromHere(lengths[i])));
     }
 
     /// <summary>
     /// Try to read and parse the default STM file given by Lumina.
     /// </summary>
     public StmFile(IDataManager gameData)
-        : this(gameData.GetFile(Path)?.Data ?? [])
+        : this(gameData.GetFile(TDyePack.DefaultStmPath)?.Data ?? [])
     { }
 }

--- a/Files/StmFile.cs
+++ b/Files/StmFile.cs
@@ -5,7 +5,7 @@ using Penumbra.GameData.Structs;
 
 namespace Penumbra.GameData.Files;
 
-public partial class StmFile<TDyePack> where TDyePack : unmanaged, IDyePack<TDyePack>
+public partial class StmFile<TDyePack> where TDyePack : unmanaged, IDyePack
 {
     public const string LegacyPath = LegacyDyePack.DefaultStmPath;
     public const string GudPath    = DyePack.DefaultStmPath;

--- a/Files/Utility/MmioMemoryManager.cs
+++ b/Files/Utility/MmioMemoryManager.cs
@@ -1,0 +1,65 @@
+using System.Buffers;
+using System.IO.MemoryMappedFiles;
+
+namespace Penumbra.GameData.Files.Utility;
+
+/// <summary> Allows wrapping a memory-mapped file in a <see cref="Memory{byte}"/>. </summary>
+/// <param name="accessor"> A view accessor over the file's memory. </param>
+/// <param name="file"> The file, if it shall be closed on disposal, otherwise <c>null</c>. </param>
+/// <param name="leaveOpen"> Whether to leave <paramref name="accessor"/> open on disposal. </param>
+public sealed unsafe class MmioMemoryManager(MemoryMappedViewAccessor accessor, MemoryMappedFile? file = null, bool leaveOpen = false) : MemoryManager<byte>
+{
+    private readonly MemoryMappedViewAccessor _accessor  = accessor;
+    private readonly MemoryMappedFile?        _file      = file;
+    private readonly bool                     _leaveOpen = leaveOpen;
+
+    private byte* _pointer;
+
+    public override Memory<byte> Memory
+        => CreateMemory(Length);
+
+    public bool CanRead
+        => _accessor.CanRead;
+
+    public bool CanWrite
+        => _accessor.CanWrite;
+
+    public int Length
+        => (int)_accessor.Capacity;
+
+    public MmioMemoryManager(MemoryMappedFile file, bool leaveOpen = false)
+        : this(file.CreateViewAccessor(), leaveOpen ? null : file)
+    { }
+
+    /// <seealso cref="MemoryMappedFile.CreateFromFile(string, FileMode, string?, long, MemoryMappedFileAccess)"/>
+    public static MmioMemoryManager CreateFromFile(string path, FileMode mode = FileMode.Open, string? mapName = null, long capacity = 0, MemoryMappedFileAccess access = MemoryMappedFileAccess.ReadWrite)
+        => new(MemoryMappedFile.CreateFromFile(path, mode, mapName, capacity, access));
+
+    public override Span<byte> GetSpan()
+        => new(Pin(0).Pointer, Length);
+
+    public override MemoryHandle Pin(int elementIndex = 0)
+    {
+        if (_pointer == null)
+            _accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref _pointer);
+        return new MemoryHandle(_pointer + elementIndex, pinnable: this);
+    }
+
+    public override void Unpin()
+    { }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            if (_pointer != null)
+            {
+                _pointer = null;
+                _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+            }
+            if (!_leaveOpen)
+                _accessor.Dispose();
+            _file?.Dispose();
+        }
+    }
+}

--- a/Files/Utility/MmioMemoryManager.cs
+++ b/Files/Utility/MmioMemoryManager.cs
@@ -38,11 +38,15 @@ public sealed unsafe class MmioMemoryManager(MemoryMappedViewAccessor accessor, 
     public override Span<byte> GetSpan()
         => new(Pin(0).Pointer, Length);
 
+    /// <seealso cref="MemoryMappedViewAccessor.Flush"/>
+    public void Flush()
+        => _accessor.Flush();
+
     public override MemoryHandle Pin(int elementIndex = 0)
     {
         if (_pointer == null)
             _accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref _pointer);
-        return new MemoryHandle(_pointer + elementIndex, pinnable: this);
+        return new MemoryHandle(_pointer + _accessor.PointerOffset + elementIndex, pinnable: this);
     }
 
     public override void Unpin()

--- a/Files/Utility/SpanBinaryReader.cs
+++ b/Files/Utility/SpanBinaryReader.cs
@@ -1,4 +1,4 @@
-﻿namespace Penumbra.GameData.Files.Utility;
+namespace Penumbra.GameData.Files.Utility;
 
 /// <summary>
 /// Equivalent to <see cref="BinaryReader"/>, but for <see cref="ReadOnlySpan{Byte}"/>.
@@ -32,8 +32,18 @@ public unsafe ref struct SpanBinaryReader
 
     public int Remaining { get; private set; }
 
-    public int Count
+    public readonly int Count
         => Length;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public void Skip(int numBytes)
+    {
+        if (Remaining < numBytes)
+            throw new EndOfStreamException();
+
+        _pos      =  ref Unsafe.Add(ref _pos, numBytes);
+        Remaining -= numBytes;
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public T Read<T>() where T : unmanaged

--- a/Structs/HalfColor.cs
+++ b/Structs/HalfColor.cs
@@ -1,0 +1,43 @@
+namespace Penumbra.GameData.Structs;
+
+/// <summary>
+/// A RGB tuple of <see cref="Half"/>. Used for color tables notably.
+/// </summary>
+[StructLayout(LayoutKind.Sequential, Pack = 2)]
+public struct HalfColor(Half red, Half green, Half blue) : IEquatable<HalfColor>
+{
+    public static readonly HalfColor Black = new(Half.Zero, Half.Zero, Half.Zero);
+    public static readonly HalfColor White = new(Half.One,  Half.One,  Half.One);
+
+    public Half Red   = red;
+    public Half Green = green;
+    public Half Blue  = blue;
+
+    public readonly void Deconstruct(out Half red, out Half green, out Half blue)
+    {
+        red   = Red;
+        green = Green;
+        blue  = Blue;
+    }
+
+    public override readonly bool Equals(object? obj)
+        => obj is HalfColor other && Equals(other);
+
+    public readonly bool Equals(HalfColor other)
+        => Red == other.Red && Green == other.Green && Blue == other.Blue;
+
+    public override int GetHashCode()
+        => HashCode.Combine(Red, Green, Blue);
+
+    public static explicit operator Vector3(HalfColor color)
+        => new((float)color.Red, (float)color.Green, (float)color.Blue);
+
+    public static explicit operator HalfColor(Vector3 color)
+        => new((Half)color.X, (Half)color.Y, (Half)color.Z);
+
+    public static bool operator ==(HalfColor left, HalfColor right)
+        => left.Equals(right);
+
+    public static bool operator !=(HalfColor left, HalfColor right)
+        => !left.Equals(right);
+}

--- a/Structs/HalfMatrix2x2.cs
+++ b/Structs/HalfMatrix2x2.cs
@@ -1,0 +1,62 @@
+namespace Penumbra.GameData.Structs;
+
+[StructLayout(LayoutKind.Sequential)]
+public struct HalfMatrix2x2(Half uu, Half uv, Half vu, Half vv) : IEquatable<HalfMatrix2x2>
+{
+    public static readonly HalfMatrix2x2 Zero     = new(Half.Zero, Half.Zero, Half.Zero, Half.Zero);
+    public static readonly HalfMatrix2x2 Identity = new(Half.One,  Half.Zero, Half.Zero, Half.One);
+
+    public Half UU = uu;
+    public Half UV = uv;
+    public Half VU = vu;
+    public Half VV = vv;
+
+    public static HalfMatrix2x2 Compose(Vector2 scale, float rotation, float shear)
+    {
+        var vLength = scale.Y / MathF.Cos(shear);
+        var vAngle  = shear + MathF.PI * 0.5f + rotation;
+        return new(
+            (Half)(scale.X * MathF.Cos(rotation)),
+            (Half)(vLength * MathF.Cos(vAngle)),
+            (Half)(scale.X * MathF.Sin(rotation)),
+            (Half)(vLength * MathF.Sin(vAngle)));
+    }
+
+    public readonly void Decompose(out Vector2 scale, out float rotation, out float shear)
+    {
+        var floats = (Vector4)this;
+        var scaleX = MathF.Sqrt(floats.X * floats.X + floats.Z * floats.Z);
+        rotation   = MathF.Atan2(floats.Z, floats.X);
+        shear      = MathF.Atan2(floats.W, floats.Y) - MathF.PI * 0.5f - rotation;
+        if (shear < -MathF.PI)
+            shear += MathF.Tau;
+        else if (shear > MathF.PI)
+            shear -= MathF.Tau;
+        var scaleY = MathF.Sqrt(floats.Y * floats.Y + floats.W * floats.W) * MathF.Cos(shear);
+        scale      = new(scaleX, scaleY);
+    }
+
+    public override readonly bool Equals([NotNullWhen(true)] object? obj)
+        => obj is HalfMatrix2x2 other && Equals(other);
+
+    public readonly bool Equals(HalfMatrix2x2 other)
+        => UU == other.UU && UV == other.UV && VU == other.VU && VV == other.VV;
+
+    public override readonly int GetHashCode()
+        => HashCode.Combine(UU, UV, VU, VV);
+
+    public static HalfMatrix2x2 ScaledIdentity(Half scale)
+        => new(scale, Half.Zero, Half.Zero, scale);
+
+    public static explicit operator Vector4(HalfMatrix2x2 mat)
+        => new((float)mat.UU, (float)mat.UV, (float)mat.VU, (float)mat.VV);
+
+    public static explicit operator HalfMatrix2x2(Vector4 mat)
+        => new((Half)mat.X, (Half)mat.Y, (Half)mat.Z, (Half)mat.W);
+
+    public static bool operator ==(HalfMatrix2x2 left, HalfMatrix2x2 right)
+        => left.Equals(right);
+
+    public static bool operator !=(HalfMatrix2x2 left, HalfMatrix2x2 right)
+        => !left.Equals(right);
+}

--- a/Structs/SharedSet.cs
+++ b/Structs/SharedSet.cs
@@ -1,0 +1,297 @@
+
+namespace Penumbra.GameData.Structs;
+
+public struct SharedSet<TItem, TBitVector>(SharedSet<TItem, TBitVector>.Universe? possibleValues) : IEnumerable<TItem>, IEquatable<SharedSet<TItem, TBitVector>>, ICloneable
+    where TItem : IEquatable<TItem> where TBitVector : unmanaged, IBinaryInteger<TBitVector>
+{
+    public readonly Universe?  PossibleValues = possibleValues;
+    private         TBitVector _bitVector;
+
+    public readonly TBitVector BitVector
+        => _bitVector;
+
+    public readonly int Count
+        => int.CreateSaturating(TBitVector.PopCount(_bitVector));
+
+    private SharedSet(Universe? possibleValues, TBitVector bitVector) : this(possibleValues)
+    {
+        _bitVector = bitVector;
+    }
+
+    public bool Add(TItem value)
+    {
+        if (PossibleValues == null)
+            throw new NotSupportedException($"Cannot add anything to a SharedSet without a backing Universe");
+        var index = PossibleValues.Find(value, true);
+        var mask  = TBitVector.One << index;
+        if ((_bitVector & mask) != TBitVector.Zero)
+            return false;
+        _bitVector |= mask;
+        return true;
+    }
+
+    public bool AddExisting(TItem value)
+    {
+        if (PossibleValues == null)
+            return false;
+        var index = PossibleValues.Find(value, true);
+        if (index < 0)
+            return false;
+        var mask = TBitVector.One << index;
+        if ((_bitVector & mask) != TBitVector.Zero)
+            return false;
+        _bitVector |= mask;
+        return true;
+    }
+
+    public bool Remove(TItem value)
+    {
+        if (PossibleValues == null)
+            return false;
+        var index = PossibleValues.Find(value, false);
+        if (index < 0)
+            return false;
+        var mask = TBitVector.One << index;
+        if ((_bitVector & mask) == TBitVector.Zero)
+            return false;
+        _bitVector &= ~mask;
+        return true;
+    }
+
+    public readonly bool Contains(TItem value)
+    {
+        if (PossibleValues == null)
+            return false;
+        var index = PossibleValues.Find(value, false);
+        if (index < 0)
+            return false;
+        var mask = TBitVector.One << index;
+        return (_bitVector & mask) != TBitVector.Zero;
+    }
+
+    public readonly bool IsSubsetOf(SharedSet<TItem, TBitVector> other)
+        => PossibleValues == other.PossibleValues && (_bitVector & other._bitVector) == _bitVector;
+
+    public readonly bool IsProperSubsetOf(SharedSet<TItem, TBitVector> other)
+        => IsSubsetOf(other) && _bitVector != other._bitVector;
+
+    public readonly bool IsSupersetOf(SharedSet<TItem, TBitVector> other)
+        => PossibleValues == other.PossibleValues && (_bitVector & other._bitVector) == other._bitVector;
+
+    public readonly bool IsProperSupersetOf(SharedSet<TItem, TBitVector> other)
+        => IsSupersetOf(other) && _bitVector != other._bitVector;
+
+    public readonly bool Overlaps(SharedSet<TItem, TBitVector> other)
+        => PossibleValues == other.PossibleValues && (_bitVector & other._bitVector) != TBitVector.Zero;
+
+    public readonly SharedSet<TItem, TBitVector> CreateShared()
+        => new(PossibleValues);
+
+    public readonly Enumerator GetEnumerator()
+        => new(this);
+
+    readonly IEnumerator<TItem> IEnumerable<TItem>.GetEnumerator()
+        => new Enumerator(this);
+
+    readonly IEnumerator IEnumerable.GetEnumerator()
+        => new Enumerator(this);
+
+    readonly object ICloneable.Clone()
+        => this;
+
+    public static SharedSet<TItem, TBitVector> CreateNew()
+        => new([]);
+
+    public override readonly bool Equals([NotNullWhen(true)] object? obj)
+        => obj is SharedSet<TItem, TBitVector> other && Equals(other);
+
+    public readonly bool Equals(SharedSet<TItem, TBitVector> other)
+        => PossibleValues == other.PossibleValues && _bitVector == other._bitVector;
+
+    public override readonly int GetHashCode()
+        => HashCode.Combine(PossibleValues, _bitVector);
+
+    public static bool operator ==(SharedSet<TItem, TBitVector> lhs, SharedSet<TItem, TBitVector> rhs)
+        => lhs.Equals(rhs);
+
+    public static bool operator !=(SharedSet<TItem, TBitVector> lhs, SharedSet<TItem, TBitVector> rhs)
+        => !lhs.Equals(rhs);
+
+    public static SharedSet<TItem, TBitVector> operator ~(SharedSet<TItem, TBitVector> value)
+        => new(value.PossibleValues, value.PossibleValues == null ? TBitVector.Zero : ((TBitVector.One << value.PossibleValues.Count) - TBitVector.One) ^ value._bitVector);
+
+    public static SharedSet<TItem, TBitVector> operator &(SharedSet<TItem, TBitVector> lhs, SharedSet<TItem, TBitVector> rhs)
+        => lhs.PossibleValues == rhs.PossibleValues
+            ? new(lhs.PossibleValues, lhs._bitVector & rhs._bitVector)
+            : throw new ArgumentException($"Cannot combine SharedSets not backed by the same Universe");
+
+    public static SharedSet<TItem, TBitVector> operator |(SharedSet<TItem, TBitVector> lhs, SharedSet<TItem, TBitVector> rhs)
+        => lhs.PossibleValues == rhs.PossibleValues
+            ? new(lhs.PossibleValues, lhs._bitVector | rhs._bitVector)
+            : throw new ArgumentException($"Cannot combine SharedSets not backed by the same Universe");
+
+    public static SharedSet<TItem, TBitVector> operator ^(SharedSet<TItem, TBitVector> lhs, SharedSet<TItem, TBitVector> rhs)
+        => lhs.PossibleValues == rhs.PossibleValues
+            ? new(lhs.PossibleValues, lhs._bitVector ^ rhs._bitVector)
+            : throw new ArgumentException($"Cannot combine SharedSets not backed by the same Universe");
+
+    public class Universe : IReadOnlyList<TItem>
+    {
+        protected readonly TItem[] Array;
+        protected          int     InternalCount;
+
+        public int Capacity
+            => Array.Length;
+
+        public int Count
+            => InternalCount;
+
+        public TItem this[int index]
+            => index >= 0 && index < InternalCount
+                ? Array[index]
+                : throw new IndexOutOfRangeException($"Index {index} out of range of SharedSet.Universe of count {InternalCount}");
+
+        public ReadOnlySpan<TItem> Span
+            => Array.AsSpan(0, InternalCount);
+
+        public unsafe Universe()
+        {
+            Array = new TItem[sizeof(TBitVector) << 3];
+        }
+
+        public Universe(IEnumerable<TItem> items) : this()
+        {
+            foreach (var item in items)
+                Find(item, true);
+        }
+
+        public ReadOnlySpan<TItem>.Enumerator GetEnumerator()
+            => Span.GetEnumerator();
+
+        IEnumerator<TItem> IEnumerable<TItem>.GetEnumerator()
+            => Array.Take(InternalCount).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => Array.Take(InternalCount).GetEnumerator();
+
+        public SharedSet<TItem, TBitVector> EmptySet()
+            => new(this);
+
+        public SharedSet<TItem, TBitVector> FullSet()
+            => ~EmptySet();
+
+        public int IndexOf(TItem value)
+            => Find(value, false);
+
+        public int Add(TItem value)
+            => Find(value, true);
+
+        public virtual int Find(TItem value, bool orAdd)
+        {
+            for (var i = 0; i < InternalCount; ++i)
+            {
+                if (value.Equals(Array[i]))
+                    return i;
+            }
+
+            if (!orAdd)
+                return -1;
+
+            if (InternalCount == Array.Length)
+                throw new InvalidOperationException($"The SharedSet.Universe (of capacity {Array.Length}) is full");
+
+            var newI    = InternalCount++;
+            Array[newI] = value;
+
+            return newI;
+        }
+
+        public override string ToString()
+            => $"{GetType().Name} {{ {string.Join(", ", this)} }}";
+
+        public static implicit operator SharedSet<TItem, TBitVector>(Universe values)
+            => values.FullSet();
+    }
+
+    public class SortedUniverse(IComparer<TItem>? comparer = null) : Universe()
+    {
+        public SortedUniverse(IEnumerable<TItem> items, IComparer<TItem>? comparer = null) : this(comparer)
+        {
+            foreach (var item in items)
+            {
+                var i = System.Array.BinarySearch(Array, 0, InternalCount, item, comparer);
+                if (i < 0)
+                {
+                    if (InternalCount == Array.Length)
+                        throw new InvalidOperationException($"The SharedSet.Universe (of capacity {Array.Length}) is full");
+
+                    // Inserting items in the middle violates the invariant that a Universe's Array must be append-only,
+                    // but it is not an issue to do so during construction, as no SharedSet can possibly be backed by it yet.
+
+                    i = ~i;
+                    for (var j = InternalCount; j-- > i;)
+                        Array[j + 1] = Array[j];
+                    Array[i] = item;
+                    ++InternalCount;
+                }
+            }
+        }
+
+        public override int Find(TItem value, bool orAdd)
+        {
+            var i = System.Array.BinarySearch(Array, 0, InternalCount, value, comparer);
+            if (i >= 0)
+                return i;
+
+            if (!orAdd)
+                return -1;
+
+            if (InternalCount == Array.Length)
+                throw new InvalidOperationException($"The SharedSet.Universe (of capacity {Array.Length}) is full");
+
+            i = ~i;
+            if (i != InternalCount)
+                throw new ArgumentException($"Elements must be inserted in the SharedSet.SortedUniverse in ascending order");
+
+            Array[InternalCount++] = value;
+
+            return i;
+        }
+    }
+
+    public struct Enumerator(SharedSet<TItem, TBitVector> set) : IEnumerator<TItem>
+    {
+        private readonly Universe?  _possibleValues = set.PossibleValues;
+        private readonly TBitVector _bitVector      = set._bitVector;
+        private          int        _position       = -1;
+
+        public readonly TItem Current
+            => _possibleValues![_position];
+
+        readonly object IEnumerator.Current
+            => _possibleValues![_position];
+
+        public void Reset()
+        {
+            _position = -1;
+        }
+
+        public bool MoveNext()
+        {
+            if (_possibleValues == null)
+                return false;
+
+            while (_position < _possibleValues.Count)
+            {
+                ++_position;
+                if ((_bitVector & (TBitVector.One << _position)) != TBitVector.Zero)
+                    return true;
+            }
+
+            return false;
+        }
+
+        public readonly void Dispose()
+        { }
+    }
+}

--- a/UtilityFunctions.cs
+++ b/UtilityFunctions.cs
@@ -1,4 +1,6 @@
+using Lumina.Data.Parsing;
 using OtterGui;
+using Penumbra.GameData.Files.MaterialStructs;
 
 namespace Penumbra.GameData;
 
@@ -33,13 +35,12 @@ public static class UtilityFunctions
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static T[] AddItem<T>(this T[] array, T element, int count = 1)
     {
-        var length   = array.Length;
-        var newArray = new T[array.Length + count];
-        Array.Copy(array, newArray, length);
-        for (var i = length; i < newArray.Length; ++i)
-            newArray[i] = element;
+        var length = array.Length;
+        Array.Resize(ref array, length + count);
+        for (var i = length; i < array.Length; ++i)
+            array[i] = element;
 
-        return newArray;
+        return array;
     }
 
     /// <summary> Remove <paramref name="count"/> items starting from <paramref name="offset"/> from an array. </summary>
@@ -55,4 +56,19 @@ public static class UtilityFunctions
         Array.Copy(array, offset + count, newArray, offset, newArray.Length - offset);
         return newArray;
     }
+
+    /// <summary> Reinterprets some memory as another type. </summary>
+    /// <typeparam name="TFrom"> Source type. </typeparam>
+    /// <typeparam name="TTo"> Target type. Must be smaller or of the same size as the source type. </typeparam>
+    /// <param name="value"> The reference to reinterpret. </param>
+    /// <param name="index"> If several instances of the target type fit in the source type, index of the one to use. </param>
+    /// <returns> Reinterpreted reference. </returns>
+    /// <seealso cref="MemoryMarshal.Cast{TFrom, TTo}(Span{TFrom})"/>
+    internal static ref TTo Cast<TFrom, TTo>(ref TFrom value, int index = 0) where TFrom : struct where TTo : struct
+        => ref MemoryMarshal.Cast<TFrom, TTo>(new Span<TFrom>(ref value))[index];
+
+    /// <inheritdoc cref="Cast{TFrom, TTo}(ref TFrom, int)"/>
+    /// <seealso cref="MemoryMarshal.Cast{TFrom, TTo}(ReadOnlySpan{TFrom})"/>
+    internal static ref readonly TTo ReadOnlyCast<TFrom, TTo>(in TFrom value, int index = 0) where TFrom : struct where TTo : struct
+        => ref MemoryMarshal.Cast<TFrom, TTo>(new ReadOnlySpan<TFrom>(in value))[index];
 }


### PR DESCRIPTION
Goes with https://github.com/xivdev/Penumbra/pull/439

# Stain Maps
- Implement support for STM 2.0 (variable color and scalar columns) ;
- Preserve support for STM 1.1 (hardcoded to have 3 color and 2 scalar column) ;
- Change the parser to be span-based (so it can be used to opportunistically parse the already loaded STMs from `CharacterUtility`, avoiding redundant I/O) ;
- Make the class generic over a dye pack type, that must be a sequential struct with color fields first, then scalar fields.

# Shader Packages
- Add deeper analysis facilities (notably related to shader filtering, by key and/or by rendering pass) ;
- Add faster analysis facilities (`IsLegacy` and name extraction), as a complete DT ShPk parse takes hundreds of milliseconds (even without this PR), which introduces unacceptable delays in some existing and future scenarios ;
- Add a dictionary of known shader key/parameter names, that will be updated from time to time as we find out more of them.

# Materials
- Implement wrappers over some bitfields of the file format ;
- Implement support for all(?) shapes and sizes of color tables (legacy, new, and limited support for variable-size CTs the file format is able to represent) ;
- Rework constants to be stored internally as a byte array, and exposed generically, to work with non-float constants ;
- Improve the legacy material migration function.

# Technical bits
- Add types to compactly represent many subsets of [a common set](https://en.wikipedia.org/wiki/Universe_(mathematics)) ;
- Add a memory-mapped I/O `Memory<byte>` facility, that can then be used to call constructors and methods taking `ReadOnlySpan<byte>`s over lazily-read files.