### PR TITLE
Material constant pinning

### DIFF
--- a/Files/MtrlFile.AddRemove.cs
+++ b/Files/MtrlFile.AddRemove.cs
@@ -128,6 +128,9 @@ public partial class MtrlFile
     {
         static bool ShallKeepConstant(MtrlFile mtrl, ShpkFile shpk, Constant constant)
         {
+            if (constant.Pinned)
+                return true;
+
             if ((constant.ByteOffset & 0x3) != 0 || (constant.ByteSize & 0x3) != 0)
                 return true;
 


### PR DESCRIPTION
Given stuff isn't reordered within an editing session, this should be enough to restore round-trip I/O of vanilla materials.

:warning: I cannot test it for now.