### PR TITLE
Proper NPC/Companion names

### DIFF
--- a/DataContainers/DictBNpc.cs
+++ b/DataContainers/DictBNpc.cs
@@ -1,25 +1,27 @@
 using System.Collections.Frozen;
+using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 using Lumina.Excel.Sheets;
 using OtterGui.Log;
-using Penumbra.GameData.Data;
 using Penumbra.GameData.DataContainers.Bases;
 using Penumbra.GameData.Structs;
 
 namespace Penumbra.GameData.DataContainers;
 
+#pragma warning disable SeStringEvaluator
+
 /// <summary> A dictionary that matches BNpcNameId to names. </summary>
-public sealed class DictBNpc(IDalamudPluginInterface pluginInterface, Logger log, IDataManager gameData)
-    : NameDictionary(pluginInterface, log, gameData, "BNpcs", Version.DictBNpc, () => CreateBNpcData(gameData))
+public sealed class DictBNpc(IDalamudPluginInterface pluginInterface, Logger log, IDataManager gameData, ISeStringEvaluator evaluator)
+    : NameDictionary(pluginInterface, log, gameData, "BNpcs", Version.DictBNpc, () => CreateBNpcData(gameData, evaluator))
 {
     /// <summary> Create the data. </summary>
-    private static IReadOnlyDictionary<uint, string> CreateBNpcData(IDataManager gameData)
+    private static IReadOnlyDictionary<uint, string> CreateBNpcData(IDataManager gameData, ISeStringEvaluator evaluator)
     {
         var sheet = gameData.GetExcelSheet<BNpcName>(gameData.Language)!;
-        var dict  = new Dictionary<uint, string>((int) sheet.Count);
+        var dict = new Dictionary<uint, string>(sheet.Count);
         foreach (var n in sheet.Where(n => n.Singular.ByteLength > 0))
-            dict.TryAdd(n.RowId, DataUtility.ToTitleCaseExtended(n.Singular, n.Article));
+            dict.TryAdd(n.RowId, evaluator.EvaluateObjStr(ObjectKind.BattleNpc, n.RowId, gameData.Language));
         return dict.ToFrozenDictionary();
     }
 

--- a/DataContainers/DictCompanion.cs
+++ b/DataContainers/DictCompanion.cs
@@ -1,25 +1,27 @@
 using System.Collections.Frozen;
+using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 using Lumina.Excel.Sheets;
 using OtterGui.Log;
-using Penumbra.GameData.Data;
 using Penumbra.GameData.DataContainers.Bases;
 using Penumbra.GameData.Structs;
 
 namespace Penumbra.GameData.DataContainers;
 
+#pragma warning disable SeStringEvaluator
+
 /// <summary> A dictionary that matches CompanionId to names. </summary>
-public sealed class DictCompanion(IDalamudPluginInterface pluginInterface, Logger log, IDataManager gameData)
-    : NameDictionary(pluginInterface, log, gameData, "Companions", Version.DictCompanion, () => CreateCompanionData(gameData))
+public sealed class DictCompanion(IDalamudPluginInterface pluginInterface, Logger log, IDataManager gameData, ISeStringEvaluator evaluator)
+    : NameDictionary(pluginInterface, log, gameData, "Companions", Version.DictCompanion, () => CreateCompanionData(gameData, evaluator))
 {
     /// <summary> Create the data. </summary>
-    private static IReadOnlyDictionary<uint, string> CreateCompanionData(IDataManager gameData)
+    private static IReadOnlyDictionary<uint, string> CreateCompanionData(IDataManager gameData, ISeStringEvaluator evaluator)
     {
         var sheet = gameData.GetExcelSheet<Companion>(gameData.Language)!;
-        var dict  = new Dictionary<uint, string>((int) sheet.Count);
+        var dict = new Dictionary<uint, string>(sheet.Count);
         foreach (var c in sheet.Where(c => c.Singular.ByteLength > 0 && c.Order < ushort.MaxValue))
-            dict.TryAdd(c.RowId, DataUtility.ToTitleCaseExtended(c.Singular, c.Article));
+            dict.TryAdd(c.RowId, evaluator.EvaluateObjStr(ObjectKind.Companion, c.RowId, gameData.Language));
         return dict.ToFrozenDictionary();
     }
 

--- a/DataContainers/DictENpc.cs
+++ b/DataContainers/DictENpc.cs
@@ -1,26 +1,27 @@
 using System.Collections.Frozen;
-using Dalamud.Game;
+using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 using Lumina.Excel.Sheets;
 using OtterGui.Log;
-using Penumbra.GameData.Data;
 using Penumbra.GameData.DataContainers.Bases;
 using Penumbra.GameData.Structs;
 
 namespace Penumbra.GameData.DataContainers;
 
+#pragma warning disable SeStringEvaluator
+
 /// <summary> A dictionary that matches ENpcId to names. </summary>
-public sealed class DictENpc(IDalamudPluginInterface pluginInterface, Logger log, IDataManager gameData)
-    : NameDictionary(pluginInterface, log, gameData, "ENpcs", Version.DictENpc, () => CreateENpcData(gameData))
+public sealed class DictENpc(IDalamudPluginInterface pluginInterface, Logger log, IDataManager gameData, ISeStringEvaluator evaluator)
+    : NameDictionary(pluginInterface, log, gameData, "ENpcs", Version.DictENpc, () => CreateENpcData(gameData, evaluator))
 {
     /// <summary> Create the data. </summary>
-    private static IReadOnlyDictionary<uint, string> CreateENpcData(IDataManager gameData)
+    private static IReadOnlyDictionary<uint, string> CreateENpcData(IDataManager gameData, ISeStringEvaluator evaluator)
     {
         var sheet = gameData.GetExcelSheet<ENpcResident>(gameData.Language);
-        var dict  = new Dictionary<uint, string>(sheet.Count);
+        var dict = new Dictionary<uint, string>(sheet.Count);
         foreach (var n in sheet.Where(e => e.Singular.ByteLength > 0))
-            dict.TryAdd(n.RowId, DataUtility.ToTitleCaseExtended(n.Singular, n.Article));
+            dict.TryAdd(n.RowId, evaluator.EvaluateObjStr(ObjectKind.EventNpc, n.RowId, gameData.Language));
         return dict.ToFrozenDictionary();
     }
 


### PR DESCRIPTION
Yo Otter,

as you know, I worked a lot on SeStrings and made a evaluator for them that landed in Dalamud.
That also includes the noun system, so we can get rid of `[a]` and `[p]` etc. in BattleNpc, Companion and EventNpc names.

The changes aren't too big: instead of getting the name from the sheet directly, it calls `ISeStringEvaluator.EvaluateObjStr()` with the ObjectKind and the RowId to get a singular name for it.

Additionally to this PR it will require you to add `ISeStringEvaluator` and the `#pragma warning disable SeStringEvaluator` line (since the service is marked experimental) to https://github.com/xivdev/Penumbra/blob/master/Penumbra/Services/StaticServiceManager.cs and https://github.com/Ottermandias/Glamourer/blob/main/Glamourer/Services/DalamudServices.cs (+ wherever else it is needed).

I'm not sure if this is version bump worthy and how that all works, so I'll leave that to you.

\- Hasel :v: