### PR TITLE
Recognize head equipment as glasses

### DIFF
--- a/Enums/BonusItemFlag.cs
+++ b/Enums/BonusItemFlag.cs
@@ -65,6 +65,13 @@ public static partial class BonusExtensions
             _                     => EquipSlot.Unknown,
         };
 
+    public static BonusItemFlag ToBonusSlot(this EquipSlot value)
+        => value switch
+        {
+            EquipSlot.Head => BonusItemFlag.Glasses,
+            _              => BonusItemFlag.Unknown,
+        };
+
     public static BonusItemFlag ToBonusSlot(this uint slot)
         => slot switch
         {

--- a/Enums/FullEquipType.cs
+++ b/Enums/FullEquipType.cs
@@ -367,6 +367,7 @@ public static partial class FullEquipTypeExtensions
     public static BonusItemFlag ToBonus(this FullEquipType type)
         => type switch
         {
+            FullEquipType.Head    => EquipSlot.Head.ToBonusSlot(),
             FullEquipType.Glasses => BonusItemFlag.Glasses,
             _                     => BonusItemFlag.Unknown,
         };

--- a/Structs/EquipItem.cs
+++ b/Structs/EquipItem.cs
@@ -191,7 +191,7 @@ public readonly struct EquipItem : IEquatable<EquipItem>
     public static EquipItem FromBonusIds(BonusItemId itemId, IconId iconId, PrimaryId modelId, Variant variant, BonusItemFlag type, string? name = null)
     {
         name ??= $"Unknown ({modelId}-{variant})";
-        var fullId = itemId.Id is 0
+        var fullId = itemId.Id is 0 || itemId == BonusItemId.Invalid
             ? new CustomItemId(modelId, variant, type)
             : itemId;
         return new EquipItem(name, fullId, iconId, modelId, 0, variant, type.ToEquipType(), 0, 0, 0);


### PR DESCRIPTION
This fixes forcing head equipment as glasses in Glamourer designs through Ctrl+Enter, and persistence thereof.